### PR TITLE
Release 0.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>io.getlime.security</groupId>
 	<artifactId>powerauth-restful-integration-parent</artifactId>
-	<version>0.17.0</version>
+	<version>0.17.1</version>
 	<packaging>pom</packaging>
 
 	<parent>

--- a/powerauth-restful-model/pom.xml
+++ b/powerauth-restful-model/pom.xml
@@ -24,14 +24,14 @@
 
 	<groupId>io.getlime.security</groupId>
 	<artifactId>powerauth-restful-model</artifactId>
-	<version>0.17.0</version>
+	<version>0.17.1</version>
 	<name>powerauth-restful-model</name>
 	<description>Model classes PowerAuth Standard RESTful API</description>
 
 	<parent>
 		<groupId>io.getlime.security</groupId>
 		<artifactId>powerauth-restful-integration-parent</artifactId>
-		<version>0.17.0</version>
+		<version>0.17.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>io.getlime.core</groupId>
 			<artifactId>rest-model-base</artifactId>
-			<version>1.0.2</version>
+			<version>1.0.3</version>
 		</dependency>
 	</dependencies>
 

--- a/powerauth-restful-security-base/pom.xml
+++ b/powerauth-restful-security-base/pom.xml
@@ -26,12 +26,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-restful-security-base</artifactId>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.17.0</version>
+        <version>0.17.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-model</artifactId>
-            <version>0.17.0</version>
+            <version>0.17.1</version>
         </dependency>
 
     </dependencies>

--- a/powerauth-restful-security-javaee/pom.xml
+++ b/powerauth-restful-security-javaee/pom.xml
@@ -25,14 +25,14 @@
 
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-restful-security-javaee</artifactId>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
     <name>powerauth-restful-security-javaee</name>
     <description>PowerAuth 2.0 RESTful API Security Additions for EJB</description>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.17.0</version>
+        <version>0.17.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-base</artifactId>
-            <version>0.17.0</version>
+            <version>0.17.1</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>

--- a/powerauth-restful-security-spring/pom.xml
+++ b/powerauth-restful-security-spring/pom.xml
@@ -24,14 +24,14 @@
 
 	<groupId>io.getlime.security</groupId>
 	<artifactId>powerauth-restful-security-spring</artifactId>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
     <name>powerauth-restful-security-spring</name>
 	<description>PowerAuth 2.0 RESTful API Security Additions for Spring</description>
 
 	<parent>
 		<groupId>io.getlime.security</groupId>
 		<artifactId>powerauth-restful-integration-parent</artifactId>
-		<version>0.17.0</version>
+		<version>0.17.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>io.getlime.security</groupId>
 			<artifactId>powerauth-restful-security-base</artifactId>
-			<version>0.17.0</version>
+			<version>0.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.getlime.security</groupId>

--- a/powerauth-restful-server-javaee/pom.xml
+++ b/powerauth-restful-server-javaee/pom.xml
@@ -28,12 +28,12 @@
     <artifactId>powerauth-restful-server-javaee</artifactId>
     <name>powerauth-restful-server-javaee</name>
     <packaging>war</packaging>
-    <version>0.17.0</version>
+    <version>0.17.1</version>
 
     <parent>
         <artifactId>powerauth-restful-integration-parent</artifactId>
         <groupId>io.getlime.security</groupId>
-        <version>0.17.0</version>
+        <version>0.17.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-restful-security-javaee</artifactId>
-            <version>0.17.0</version>
+            <version>0.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/powerauth-restful-server-spring/pom.xml
+++ b/powerauth-restful-server-spring/pom.xml
@@ -27,13 +27,13 @@
 	<description>PowerAuth 2.0 Standard RESTful API</description>
 	<groupId>io.getlime.security</groupId>
 	<artifactId>powerauth-restful-server-spring</artifactId>
-	<version>0.17.0</version>
+	<version>0.17.1</version>
 	<packaging>war</packaging>
 
 	<parent>
 		<groupId>io.getlime.security</groupId>
 		<artifactId>powerauth-restful-integration-parent</artifactId>
-		<version>0.17.0</version>
+		<version>0.17.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>io.getlime.security</groupId>
 			<artifactId>powerauth-restful-security-spring</artifactId>
-			<version>0.17.0</version>
+			<version>0.17.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This is a hotfix release that removes dependency on Guava from the base networking libraries. As a result, guava has to be added to the topmost project.