### PR TITLE
Fix #577: Update status endpoint for crypto4

### DIFF
--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationStatusRequest.java
@@ -1,0 +1,45 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.request.v3;
+
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Request object for /pa/v3/activation/status end-point.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Data
+public class ActivationStatusRequest {
+
+    /**
+     * Activation ID.
+     */
+    private String activationId;
+
+    /**
+     * Challenge for activation status blob encryption. Exactly 16 bytes encoded in Base64 is expected.
+     */
+    @ToString.Exclude
+    private String challenge;
+
+}

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/request/v4/ActivationStatusRequest.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/request/v4/ActivationStatusRequest.java
@@ -17,13 +17,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.rest.api.model.request;
+package com.wultra.security.powerauth.rest.api.model.request.v4;
 
 import lombok.Data;
-import lombok.ToString;
 
 /**
- * Request object for /pa/v3/activation/status end-point.
+ * Request object for /pa/v4/activation/status end-point.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  *
@@ -31,14 +30,4 @@ import lombok.ToString;
 @Data
 public class ActivationStatusRequest {
 
-    /**
-     * Activation ID.
-     */
-    private String activationId;
-
-    /**
-     * Challenge for activation status blob encryption. Exactly 16 bytes encoded in Base64 is expected.
-     */
-    @ToString.Exclude
-    private String challenge;
 }

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v3/ActivationStatusResponse.java
@@ -1,0 +1,57 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2018 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.response.v3;
+
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.Map;
+
+/**
+ * Response object for /pa/v3/activation/status end-point.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ *
+ */
+@Data
+public class ActivationStatusResponse {
+
+    /**
+     * Activation ID.
+     */
+    private String activationId;
+
+    /**
+     * Encrypted activation status blob.
+     */
+    private String encryptedStatusBlob;
+
+    /**
+     * Nonce for activation status blob encryption.
+     */
+    @ToString.Exclude
+    private String nonce;
+
+    /**
+     * Custom associated object.
+     */
+    private Map<String, Object> customObject;
+
+}

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
@@ -17,15 +17,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.wultra.security.powerauth.rest.api.model.response;
+package com.wultra.security.powerauth.rest.api.model.response.v4;
 
 import lombok.Data;
-import lombok.ToString;
 
 import java.util.Map;
 
 /**
- * Response object for /pa/v3/activation/status end-point.
+ * Response object for /pa/v4/activation/status end-point.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  *
@@ -34,20 +33,9 @@ import java.util.Map;
 public class ActivationStatusResponse {
 
     /**
-     * Activation ID.
+     * Activation status blob.
      */
-    private String activationId;
-
-    /**
-     * Encrypted activation status blob.
-     */
-    private String encryptedStatusBlob;
-
-    /**
-     * Nonce for activation status blob encryption.
-     */
-    @ToString.Exclude
-    private String nonce;
+    private String activationStatus;
 
     /**
      * Custom associated object.

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationContextConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationContextConverter.java
@@ -19,7 +19,6 @@
  */
 package com.wultra.security.powerauth.rest.api.spring.converter;
 
-import com.wultra.security.powerauth.client.model.response.GetActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.spring.model.ActivationContext;
 import org.springframework.stereotype.Component;
 
@@ -45,12 +44,49 @@ public class ActivationContextConverter {
     }
 
     /**
-     * Convert new activation context from activation status response.
+     * Convert new activation context from activation status response (V3).
      *
      * @param source Activation status response.
      * @return Activation context.
      */
-    public ActivationContext fromActivationDetailResponse(GetActivationStatusResponse source) {
+    public ActivationContext fromActivationDetailResponse(com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse source) {
+        final ActivationContext destination = new ActivationContext();
+        destination.setActivationId(source.getActivationId());
+        destination.setActivationName(source.getActivationName());
+        destination.setActivationStatus(activationStatusConverter.convertFrom(source.getActivationStatus()));
+        destination.setBlockedReason(source.getBlockedReason());
+        destination.setApplicationId(source.getApplicationId());
+        destination.setUserId(source.getUserId());
+        destination.setVersion(source.getVersion());
+        destination.setPlatform(source.getPlatform());
+        destination.setDeviceInfo(source.getDeviceInfo());
+        destination.setExtras(source.getExtras());
+        final List<String> activationFlags = source.getActivationFlags();
+        if (activationFlags != null) {
+            destination.getActivationFlags().addAll(activationFlags);
+        }
+        final Date timestampCreated = source.getTimestampCreated();
+        if (timestampCreated != null) {
+            destination.setTimestampCreated(timestampCreated.toInstant());
+        }
+        final Date timestampLastUsed = source.getTimestampLastUsed();
+        if (timestampLastUsed != null) {
+            destination.setTimestampLastUsed(timestampLastUsed.toInstant());
+        }
+        final Date timestampLastChange = source.getTimestampLastChange();
+        if (timestampLastChange != null) {
+            destination.setTimestampLastChange(timestampLastChange.toInstant());
+        }
+        return destination;
+    }
+
+    /**
+     * Convert new activation context from activation status response (V4).
+     *
+     * @param source Activation status response.
+     * @return Activation context.
+     */
+    public ActivationContext fromActivationDetailResponse(com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse source) {
         final ActivationContext destination = new ActivationContext();
         destination.setActivationId(source.getActivationId());
         destination.setActivationName(source.getActivationName());

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/ActivationController.java
@@ -35,10 +35,10 @@ import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthAuthenti
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthSignatureInvalidException;
 import com.wultra.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
-import com.wultra.security.powerauth.rest.api.model.request.ActivationStatusRequest;
+import com.wultra.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
 import com.wultra.security.powerauth.rest.api.model.response.ActivationRemoveResponse;
-import com.wultra.security.powerauth.rest.api.model.response.ActivationStatusResponse;
+import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
 import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
 import com.wultra.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ActivationController.java
@@ -19,16 +19,15 @@
  */
 package com.wultra.security.powerauth.rest.api.spring.controller.v4;
 
-import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import com.wultra.security.powerauth.http.PowerAuthSignatureHttpHeader;
 import com.wultra.security.powerauth.rest.api.model.request.ActivationRenameRequest;
-import com.wultra.security.powerauth.rest.api.model.request.ActivationStatusRequest;
+import com.wultra.security.powerauth.rest.api.model.request.v4.ActivationStatusRequest;
 import com.wultra.security.powerauth.rest.api.model.request.v4.ActivationLayer1Request;
 import com.wultra.security.powerauth.rest.api.model.response.ActivationDetailResponse;
 import com.wultra.security.powerauth.rest.api.model.response.ActivationRemoveResponse;
-import com.wultra.security.powerauth.rest.api.model.response.ActivationStatusResponse;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer1Response;
 import com.wultra.security.powerauth.rest.api.spring.annotation.EncryptedRequestBody;
 import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuth;
@@ -39,6 +38,7 @@ import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionContex
 import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthActivationException;
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthAuthenticationException;
+import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthSignatureInvalidException;
 import com.wultra.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
@@ -48,9 +48,6 @@ import com.wultra.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -95,18 +92,24 @@ public class ActivationController {
     /**
      * Get activation status.
      * @param request PowerAuth RESTful request with {@link ActivationStatusRequest} payload.
+     * @param encryptionContext Encryption context.
      * @return PowerAuth RESTful response with {@link ActivationStatusResponse} payload.
      * @throws PowerAuthActivationException In case request fails.
+     * @throws PowerAuthEncryptionException In case encryption fails.
      */
     @PostMapping("status")
-    public ObjectResponse<ActivationStatusResponse> getActivationStatus(@RequestBody ObjectRequest<ActivationStatusRequest> request)
-            throws PowerAuthActivationException {
-        if (request.getRequestObject() == null || request.getRequestObject().getActivationId() == null) {
+    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE)
+    public ActivationStatusResponse getActivationStatus(@EncryptedRequestBody ActivationStatusRequest request, EncryptionContext encryptionContext)
+            throws PowerAuthActivationException, PowerAuthEncryptionException {
+        if (request == null) {
             logger.warn("Invalid request object in activation status");
             throw new PowerAuthActivationException();
         }
-        ActivationStatusResponse response = activationServiceV4.getActivationStatus(request.getRequestObject());
-        return new ObjectResponse<>(response);
+        if (encryptionContext == null) {
+            logger.warn("Invalid encryption context in activation status");
+            throw new PowerAuthEncryptionException();
+        }
+        return activationServiceV4.getActivationStatus(encryptionContext.getActivationId());
     }
 
     /**

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/UserInfoService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/UserInfoService.java
@@ -22,7 +22,7 @@ package com.wultra.security.powerauth.rest.api.spring.service;
 import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.model.response.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.model.entity.UserInfoStage;
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthUserInfoException;
 import com.wultra.security.powerauth.rest.api.spring.model.UserInfoContext;

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v3/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v3/ActivationService.java
@@ -19,23 +19,32 @@
  */
 package com.wultra.security.powerauth.rest.api.spring.service.v3;
 
-import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
-import com.wultra.security.powerauth.client.model.request.*;
+import com.wultra.security.powerauth.client.model.request.AddActivationFlagsRequest;
+import com.wultra.security.powerauth.client.model.request.CommitActivationRequest;
+import com.wultra.security.powerauth.client.model.request.RemoveActivationRequest;
+import com.wultra.security.powerauth.client.model.request.UpdateActivationNameRequest;
 import com.wultra.security.powerauth.client.model.request.v3.CreateActivationRequest;
+import com.wultra.security.powerauth.client.model.request.v3.GetActivationStatusRequest;
 import com.wultra.security.powerauth.client.model.request.v3.PrepareActivationRequest;
-import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
+import com.wultra.security.powerauth.client.model.response.RemoveActivationResponse;
+import com.wultra.security.powerauth.client.model.response.UpdateActivationNameResponse;
 import com.wultra.security.powerauth.client.model.response.v3.CreateActivationResponse;
+import com.wultra.security.powerauth.client.model.response.v3.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.v3.PrepareActivationResponse;
+import com.wultra.security.powerauth.client.v3.PowerAuthClient;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.rest.api.model.entity.ActivationType;
 import com.wultra.security.powerauth.rest.api.model.entity.UserInfoStage;
 import com.wultra.security.powerauth.rest.api.model.request.ActivationRenameRequest;
-import com.wultra.security.powerauth.rest.api.model.request.ActivationStatusRequest;
+import com.wultra.security.powerauth.rest.api.model.request.v3.ActivationStatusRequest;
 import com.wultra.security.powerauth.rest.api.model.request.v3.ActivationLayer1Request;
-import com.wultra.security.powerauth.rest.api.model.response.*;
+import com.wultra.security.powerauth.rest.api.model.response.ActivationDetailResponse;
+import com.wultra.security.powerauth.rest.api.model.response.ActivationRemoveResponse;
+import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.model.response.v3.ActivationLayer1Response;
 import com.wultra.security.powerauth.rest.api.spring.application.PowerAuthApplicationConfiguration;
 import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
@@ -23,9 +23,10 @@ import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.request.v4.CreateActivationRequest;
+import com.wultra.security.powerauth.client.model.request.v4.GetActivationStatusRequest;
 import com.wultra.security.powerauth.client.model.request.v4.PrepareActivationRequest;
 import com.wultra.security.powerauth.client.model.response.CommitActivationResponse;
-import com.wultra.security.powerauth.client.model.response.GetActivationStatusResponse;
+import com.wultra.security.powerauth.client.model.response.v4.GetActivationStatusResponse;
 import com.wultra.security.powerauth.client.model.response.RemoveActivationResponse;
 import com.wultra.security.powerauth.client.model.response.UpdateActivationNameResponse;
 import com.wultra.security.powerauth.client.model.response.v4.CreateActivationResponse;
@@ -36,11 +37,10 @@ import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.Aead
 import com.wultra.security.powerauth.rest.api.model.entity.ActivationType;
 import com.wultra.security.powerauth.rest.api.model.entity.UserInfoStage;
 import com.wultra.security.powerauth.rest.api.model.request.ActivationRenameRequest;
-import com.wultra.security.powerauth.rest.api.model.request.ActivationStatusRequest;
 import com.wultra.security.powerauth.rest.api.model.request.v4.ActivationLayer1Request;
 import com.wultra.security.powerauth.rest.api.model.response.ActivationDetailResponse;
 import com.wultra.security.powerauth.rest.api.model.response.ActivationRemoveResponse;
-import com.wultra.security.powerauth.rest.api.model.response.ActivationStatusResponse;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationStatusResponse;
 import com.wultra.security.powerauth.rest.api.model.response.v4.ActivationLayer1Response;
 import com.wultra.security.powerauth.rest.api.spring.application.PowerAuthApplicationConfiguration;
 import com.wultra.security.powerauth.rest.api.spring.authentication.PowerAuthApiAuthentication;
@@ -425,27 +425,21 @@ public class ActivationService {
 
     /**
      * Get activation status.
-     *
-     * @param request Activation status request.
+     * @param activationId Activation identifier.
      * @return Activation status response.
      * @throws PowerAuthActivationException In case retrieving activation status fails.
      */
-    public ActivationStatusResponse getActivationStatus(ActivationStatusRequest request) throws PowerAuthActivationException {
+    public ActivationStatusResponse getActivationStatus(String activationId) throws PowerAuthActivationException {
         try {
-            final String activationId = request.getActivationId();
-            final String challenge = request.getChallenge();
             final GetActivationStatusRequest statusRequest = new GetActivationStatusRequest();
             statusRequest.setActivationId(activationId);
-            statusRequest.setChallenge(challenge);
             final GetActivationStatusResponse paResponse = powerAuthClient.getActivationStatus(
                     statusRequest,
                     httpCustomizationService.getQueryParams(),
                     httpCustomizationService.getHttpHeaders()
             );
             final ActivationStatusResponse response = new ActivationStatusResponse();
-            response.setActivationId(paResponse.getActivationId());
-            response.setEncryptedStatusBlob(paResponse.getEncryptedStatusBlob());
-            response.setNonce(paResponse.getEncryptedStatusBlobNonce());
+            response.setActivationStatus(paResponse.getStatusBlob());
             if (applicationConfiguration != null) {
                 final ActivationContext activationContext = activationContextConverter.fromActivationDetailResponse(paResponse);
                 response.setCustomObject(applicationConfiguration.statusServiceCustomObject(activationContext));


### PR DESCRIPTION
This pull request updates the /activation/status endpoint in PowerAuth RESTful Integration to support the crypto4 activation status, fix of #577.

See also changes introduced in [powerauth-server#1917](https://github.com/wultra/powerauth-server/pull/1917).