### PR TITLE
Fix #601: Configuration of allowed activation states for obtaining encryptor

### DIFF
--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuthEncryption.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuthEncryption.java
@@ -21,6 +21,7 @@ package com.wultra.security.powerauth.rest.api.spring.annotation;
 
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
+import com.wultra.security.powerauth.rest.api.spring.model.ActivationStatus;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -42,4 +43,13 @@ public @interface PowerAuthEncryption {
      * @return Encryption scope.
      */
     EncryptionScope scope() default EncryptionScope.ACTIVATION_SCOPE;
+
+    /**
+     * Allowed states for obtaining encryptor in {@link EncryptionScope#ACTIVATION_SCOPE}.
+     * This option allows configuring additional states for use cases when encryption in activation scope
+     * should work in other states than just ACTIVE.
+     * @return Allowed activation states.
+     */
+    ActivationStatus[] allowedStates() default { ActivationStatus.ACTIVE };
+
 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/support/PowerAuthAnnotationInterceptor.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/support/PowerAuthAnnotationInterceptor.java
@@ -111,7 +111,7 @@ public class PowerAuthAnnotationInterceptor implements AsyncHandlerInterceptor {
             if (powerAuthEncryptionAnnotation != null) {
                 final Type requestType = resolveGenericParameterTypeForEncryption(handlerMethod);
                 try {
-                    encryptionProvider.decryptRequest(request, requestType, powerAuthEncryptionAnnotation.scope());
+                    encryptionProvider.decryptRequest(request, requestType, powerAuthEncryptionAnnotation.scope(), powerAuthEncryptionAnnotation.allowedStates());
                     // Encryption object is saved in HTTP servlet request by encryption provider, so that it is available for Spring
                 } catch (PowerAuthEncryptionException ex) {
                     logger.warn("Decryption failed, error: {}", ex.getMessage());

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationContextConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationContextConverter.java
@@ -53,7 +53,7 @@ public class ActivationContextConverter {
         final ActivationContext destination = new ActivationContext();
         destination.setActivationId(source.getActivationId());
         destination.setActivationName(source.getActivationName());
-        destination.setActivationStatus(activationStatusConverter.convertFrom(source.getActivationStatus()));
+        destination.setActivationStatus(activationStatusConverter.convert(source.getActivationStatus()));
         destination.setBlockedReason(source.getBlockedReason());
         destination.setApplicationId(source.getApplicationId());
         destination.setUserId(source.getUserId());
@@ -90,7 +90,7 @@ public class ActivationContextConverter {
         final ActivationContext destination = new ActivationContext();
         destination.setActivationId(source.getActivationId());
         destination.setActivationName(source.getActivationName());
-        destination.setActivationStatus(activationStatusConverter.convertFrom(source.getActivationStatus()));
+        destination.setActivationStatus(activationStatusConverter.convert(source.getActivationStatus()));
         destination.setBlockedReason(source.getBlockedReason());
         destination.setApplicationId(source.getApplicationId());
         destination.setUserId(source.getUserId());

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationStatusConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/ActivationStatusConverter.java
@@ -35,7 +35,7 @@ public class ActivationStatusConverter {
      * @param activationStatus Activation status from PowerAuth client model.
      * @return Activation status from Restful integration model.
      */
-    public ActivationStatus convertFrom(com.wultra.security.powerauth.client.model.enumeration.ActivationStatus activationStatus) {
+    public ActivationStatus convert(com.wultra.security.powerauth.client.model.enumeration.ActivationStatus activationStatus) {
         if (activationStatus == null) {
             return null;
         }
@@ -46,6 +46,25 @@ public class ActivationStatusConverter {
             case ACTIVE -> ActivationStatus.ACTIVE;
             case BLOCKED -> ActivationStatus.BLOCKED;
             case REMOVED -> ActivationStatus.REMOVED;
+        };
+    }
+
+    /**
+     * Convert {@link com.wultra.security.powerauth.client.model.enumeration.ActivationStatus} from an {@link ActivationStatus} value.
+     * @param activationStatus Activation status from Restful integration model.
+     * @return Activation status from PowerAuth client model.
+     */
+    public com.wultra.security.powerauth.client.model.enumeration.ActivationStatus convert(ActivationStatus activationStatus) {
+        if (activationStatus == null) {
+            return null;
+        }
+
+        return switch (activationStatus) {
+            case CREATED -> com.wultra.security.powerauth.client.model.enumeration.ActivationStatus.CREATED;
+            case PENDING_COMMIT -> com.wultra.security.powerauth.client.model.enumeration.ActivationStatus.PENDING_COMMIT;
+            case ACTIVE -> com.wultra.security.powerauth.client.model.enumeration.ActivationStatus.ACTIVE;
+            case BLOCKED -> com.wultra.security.powerauth.client.model.enumeration.ActivationStatus.BLOCKED;
+            case REMOVED -> com.wultra.security.powerauth.client.model.enumeration.ActivationStatus.REMOVED;
         };
     }
 

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProvider.java
@@ -80,7 +80,8 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
 
     /**
      * Provider constructor.
-     * @param powerAuthClientV3 PowerAuth client.
+     * @param powerAuthClientV3 PowerAuth client (V3).
+     * @param powerAuthClientV4 PowerAuth client (V4).
      * @param activationStatusConverter Activation status converter.
      * @param httpCustomizationService HTTP customization service.
      */
@@ -153,7 +154,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             logger.debug("Error details", ex);
             return null;
         }
-        final ActivationStatus activationStatus = activationStatusConverter.convertFrom(response.getActivationStatus());
+        final ActivationStatus activationStatus = activationStatusConverter.convert(response.getActivationStatus());
         final AuthenticationContext authenticationContext = new AuthenticationContext();
         authenticationContext.setValid(response.isSignatureValid());
         authenticationContext.setRemainingAttempts(response.getRemainingAttempts() != null ? response.getRemainingAttempts().intValue() : null);
@@ -204,7 +205,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
             logger.debug("Error details", ex);
             return null;
         }
-        final ActivationStatus activationStatus = activationStatusConverter.convertFrom(response.getActivationStatus());
+        final ActivationStatus activationStatus = activationStatusConverter.convert(response.getActivationStatus());
         final AuthenticationContext authenticationContext = new AuthenticationContext();
         authenticationContext.setValid(response.isAuthenticationValid());
         authenticationContext.setRemainingAttempts(response.getRemainingAttempts() != null ? response.getRemainingAttempts().intValue() : null);
@@ -239,7 +240,7 @@ public class PowerAuthAuthenticationProvider extends PowerAuthAuthenticationProv
                     httpCustomizationService.getHttpHeaders()
             );
 
-            final ActivationStatus activationStatus = activationStatusConverter.convertFrom(response.getActivationStatus());
+            final ActivationStatus activationStatus = activationStatusConverter.convert(response.getActivationStatus());
             final AuthenticationContext authenticationContext = new AuthenticationContext();
             authenticationContext.setValid(response.isTokenValid());
             authenticationContext.setRemainingAttempts(null);

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProvider.java
@@ -23,8 +23,10 @@ import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRe
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
 import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
+import com.wultra.security.powerauth.rest.api.spring.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.rest.api.spring.encryption.PowerAuthEncryptorParameters;
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
+import com.wultra.security.powerauth.rest.api.spring.model.ActivationStatus;
 import com.wultra.security.powerauth.rest.api.spring.service.HttpCustomizationService;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -32,6 +34,9 @@ import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Implementation of PowerAuth encryption provider.
@@ -48,6 +53,7 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
     private final com.wultra.security.powerauth.client.v3.PowerAuthClient powerAuthClientV3;
     private final com.wultra.security.powerauth.client.v4.PowerAuthClient powerAuthClientV4;
     private final HttpCustomizationService httpCustomizationService;
+    private final ActivationStatusConverter activationStatusConverter;
 
     @Override
     public @Nonnull PowerAuthEncryptorParameters getEciesEncryptorParameters(@Nullable String activationId, @Nonnull String applicationKey, @Nonnull String temporaryKeyId, @Nonnull String ephemeralPublicKey, @Nonnull String version, String nonce, Long timestamp) throws PowerAuthEncryptionException {
@@ -75,8 +81,11 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
     }
 
     @Override
-    public @Nonnull PowerAuthEncryptorParameters getAeadEncryptorParameters(String activationId, @Nonnull String applicationKey, @Nonnull String temporaryKeyId, @Nonnull String version, @Nonnull String nonce, @Nonnull Long timestamp) throws PowerAuthEncryptionException {
+    public @Nonnull PowerAuthEncryptorParameters getAeadEncryptorParameters(String activationId, @Nonnull String applicationKey, @Nonnull String temporaryKeyId, @Nonnull String version, @Nonnull String nonce, @Nonnull Long timestamp, @Nonnull ActivationStatus[] allowedStates) throws PowerAuthEncryptionException {
         try {
+            final List<com.wultra.security.powerauth.client.model.enumeration.ActivationStatus> convertedStates = Stream.of(allowedStates)
+                    .map(activationStatusConverter::convert)
+                    .toList();
             final ExtractEncryptorRequest encryptorRequest = new ExtractEncryptorRequest();
             encryptorRequest.setActivationId(activationId);
             encryptorRequest.setApplicationKey(applicationKey);
@@ -84,6 +93,7 @@ public class PowerAuthEncryptionProvider extends PowerAuthEncryptionProviderBase
             encryptorRequest.setProtocolVersion(version);
             encryptorRequest.setNonce(nonce);
             encryptorRequest.setTimestamp(timestamp);
+            encryptorRequest.setAllowedStates(convertedStates);
             final ExtractEncryptorResponse encryptorResponse = powerAuthClientV4.extractEncryptor(
                     encryptorRequest,
                     httpCustomizationService.getQueryParams(),

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthEncryptionProviderBase.java
@@ -43,6 +43,7 @@ import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
 import com.wultra.security.powerauth.rest.api.spring.encryption.PowerAuthEncryptorData;
 import com.wultra.security.powerauth.rest.api.spring.encryption.PowerAuthEncryptorParameters;
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
+import com.wultra.security.powerauth.rest.api.spring.model.ActivationStatus;
 import com.wultra.security.powerauth.rest.api.spring.model.PowerAuthRequestBody;
 import com.wultra.security.powerauth.rest.api.spring.model.PowerAuthRequestObjects;
 import jakarta.annotation.Nonnull;
@@ -93,10 +94,11 @@ public abstract class PowerAuthEncryptionProviderBase {
      * @param version            Protocol version.
      * @param nonce              Nonce.
      * @param timestamp          Timestamp.
+     * @param allowedStates      Allowed activation states for obtaining encryptor in activation scope.
      * @return AEAD encryptor parameters.
      * @throws PowerAuthEncryptionException In case PowerAuth server call fails.
      */
-    public abstract @Nonnull PowerAuthEncryptorParameters getAeadEncryptorParameters(@Nullable String activationId, @Nonnull String applicationKey, @Nonnull String temporaryKeyId, @Nonnull String version, @Nonnull String nonce, @Nonnull Long timestamp) throws PowerAuthEncryptionException;
+    public abstract @Nonnull PowerAuthEncryptorParameters getAeadEncryptorParameters(@Nullable String activationId, @Nonnull String applicationKey, @Nonnull String temporaryKeyId, @Nonnull String version, @Nonnull String nonce, @Nonnull Long timestamp, @Nonnull ActivationStatus[] allowedStates) throws PowerAuthEncryptionException;
 
     /**
      * Decrypt HTTP request body and construct object with encryption data. Use the requestType parameter to specify
@@ -105,9 +107,10 @@ public abstract class PowerAuthEncryptionProviderBase {
      * @param request         HTTP request.
      * @param requestType     Class of request object.
      * @param encryptionScope Encryption scope.
+     * @param allowedStates   Allowed activation states for obtaining encryptor in activation scope.
      * @throws PowerAuthEncryptionException In case request decryption fails.
      */
-    public void decryptRequest(@Nonnull HttpServletRequest request, @Nonnull Type requestType, @Nonnull EncryptionScope encryptionScope) throws PowerAuthEncryptionException {
+    public void decryptRequest(@Nonnull HttpServletRequest request, @Nonnull Type requestType, @Nonnull EncryptionScope encryptionScope, @Nonnull ActivationStatus[] allowedStates) throws PowerAuthEncryptionException {
         // Only POST HTTP method is supported for encryption
         if (!"POST".equals(request.getMethod())) {
             logger.warn("Invalid HTTP method: {}", request.getMethod());
@@ -187,7 +190,8 @@ public abstract class PowerAuthEncryptionProviderBase {
                             temporaryKeyId,
                             version,
                             aeadRequest.getNonce(),
-                            aeadRequest.getTimestamp()
+                            aeadRequest.getTimestamp(),
+                            allowedStates
                     );
                     final byte[] secretKeyBytesAead = Base64.getDecoder().decode(encryptorParameters.secretKey());
                     final byte[] sharedInfo2BaseAead = Base64.getDecoder().decode(encryptorParameters.sharedInfo2());

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ActivationController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ActivationController.java
@@ -41,6 +41,7 @@ import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthAuthenti
 import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
 import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthCodeInvalidException;
+import com.wultra.security.powerauth.rest.api.spring.model.ActivationStatus;
 import com.wultra.security.powerauth.rest.api.spring.provider.PowerAuthAuthenticationProvider;
 import com.wultra.security.powerauth.rest.api.spring.service.v4.ActivationService;
 import com.wultra.security.powerauth.rest.api.spring.util.PowerAuthAuthenticationUtil;
@@ -98,7 +99,7 @@ public class ActivationController {
      * @throws PowerAuthEncryptionException In case encryption fails.
      */
     @PostMapping("status")
-    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE)
+    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE, allowedStates = { ActivationStatus.ACTIVE, ActivationStatus.PENDING_COMMIT, ActivationStatus.BLOCKED })
     public ActivationStatusResponse getActivationStatus(@EncryptedRequestBody ActivationStatusRequest request, EncryptionContext encryptionContext)
             throws PowerAuthActivationException, PowerAuthEncryptionException {
         if (request == null) {


### PR DESCRIPTION
It is now possible to customize activation states for obtaining an encryptor in activation scope.