### PR TITLE
Fix #634: Endpoint /rest/v4/status is missing

### DIFF
--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/ServerStatusController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/ServerStatusController.java
@@ -31,19 +31,21 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Date;
 
 /**
- * Controller that provides a user information.
+ * Controller that provides user information.
  * <p><b>PowerAuth protocol versions:</b>
  * <ul>
  *     <li>3.0</li>
  *     <li>3.1</li>
  *     <li>3.2</li>
  *     <li>3.3</li>
+ *     <li>4.0</li>
  * </ul>
  *
  * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @RestController
-@RequestMapping("pa/v3")
+@RequestMapping({"pa/v3", "pa/v4"})
 @Slf4j
 public class ServerStatusController {
 


### PR DESCRIPTION
Added `v4` version of the controller with same functionality.