### PR TITLE
Fix #689: Remove unused authentication code types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <wultra-core.version>2.1.0</wultra-core.version>
         <powerauth.version>2.0.1</powerauth.version>
-        <powerauth-crypto.version>2.0.1</powerauth-crypto.version>
+        <powerauth-crypto.version>2.1.0-SNAPSHOT</powerauth-crypto.version>
     </properties>
 
     <dependencyManagement>

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuth.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuth.java
@@ -46,14 +46,13 @@ public @interface PowerAuth {
     String resourceId();
 
     /**
-     * Types of supported authentication code types. By default, any at least 2FA authentication code type must be specified.
+     * Types of supported authentication code types. By default, any 2FA authentication code type must be specified.
      *
      * @return Supported authentication code types.
      */
     PowerAuthCodeType[] authenticationCodeType() default {
             PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_KNOWLEDGE
     };
 
     /**

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuthToken.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/annotation/PowerAuthToken.java
@@ -36,14 +36,13 @@ import java.lang.annotation.Target;
 public @interface PowerAuthToken {
 
     /**
-     * Types of supported authentication code types. By default, any at least 2FA authentication type must be specified.
+     * Types of supported authentication code types. By default, any 2FA authentication type must be specified.
      *
      * @return Supported authentication code types.
      */
     PowerAuthCodeType[] authenticationCodeType() default {
             PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_KNOWLEDGE
     };
 
 }

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/AuthenticationCodeTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/AuthenticationCodeTypeConverter.java
@@ -61,14 +61,12 @@ public class AuthenticationCodeTypeConverter {
 
     /**
      * Convert {@link AuthenticationCodeType} from {@link PowerAuthCodeType}.
-     * @param PowerAuthCodeType Authentication code type from crypto representation.
+     * @param powerAuthCodeType Authentication code type from crypto representation.
      * @return Authentication code type.
      */
-    public AuthenticationCodeType convertFrom(PowerAuthCodeType PowerAuthCodeType) {
-        return switch (PowerAuthCodeType) {
+    public AuthenticationCodeType convertFrom(PowerAuthCodeType powerAuthCodeType) {
+        return switch (powerAuthCodeType) {
             case POSSESSION -> AuthenticationCodeType.POSSESSION;
-            case KNOWLEDGE -> AuthenticationCodeType.KNOWLEDGE;
-            case BIOMETRY -> AuthenticationCodeType.BIOMETRY;
             case POSSESSION_KNOWLEDGE -> AuthenticationCodeType.POSSESSION_KNOWLEDGE;
             case POSSESSION_BIOMETRY -> AuthenticationCodeType.POSSESSION_BIOMETRY;
             default -> null;

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/SignatureTypeConverter.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/converter/SignatureTypeConverter.java
@@ -61,14 +61,12 @@ public class SignatureTypeConverter {
 
     /**
      * Convert {@link SignatureType} from {@link PowerAuthCodeType}.
-     * @param PowerAuthCodeType Signature type from crypto representation.
+     * @param powerAuthCodeType Signature type from crypto representation.
      * @return Signature type.
      */
-    public SignatureType convertFrom(PowerAuthCodeType PowerAuthCodeType) {
-        return switch (PowerAuthCodeType) {
+    public SignatureType convertFrom(PowerAuthCodeType powerAuthCodeType) {
+        return switch (powerAuthCodeType) {
             case POSSESSION -> SignatureType.POSSESSION;
-            case KNOWLEDGE -> SignatureType.KNOWLEDGE;
-            case BIOMETRY -> SignatureType.BIOMETRY;
             case POSSESSION_KNOWLEDGE -> SignatureType.POSSESSION_KNOWLEDGE;
             case POSSESSION_BIOMETRY -> SignatureType.POSSESSION_BIOMETRY;
             default -> null;

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProviderBase.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/provider/PowerAuthAuthenticationProviderBase.java
@@ -97,7 +97,7 @@ public abstract class PowerAuthAuthenticationProviderBase {
     public abstract @Nonnull PowerAuthApiAuthentication validateTokenWithActivationDetails(@Nonnull String httpAuthorizationHeader, @Nonnull List<PowerAuthCodeType> allowedAuthenticationCodeTypes) throws PowerAuthAuthenticationException;
 
     /**
-     * The same as {{@link #validateRequestAuthentication(String, byte[], String, String, List, List)} but uses default accepted authentication code type (2FA or 3FA) and does not specify forced authentication version.
+     * The same as {{@link #validateRequestAuthentication(String, byte[], String, String, List, List)} but uses default accepted authentication code types (any 2FA) and does not specify forced authentication version.
      * @param httpMethod HTTP method (GET, POST, ...)
      * @param httpBody Request body
      * @param requestUriIdentifier Request URI identifier.
@@ -109,7 +109,6 @@ public abstract class PowerAuthAuthenticationProviderBase {
         final List<PowerAuthCodeType> defaultAllowedAuthenticationCodeTypes = new ArrayList<>();
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_BIOMETRY);
-        defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
         final List<ActivationStatus> defaultAllowedStates = Collections.singletonList(ActivationStatus.ACTIVE);
         return this.validateRequestAuthentication(httpMethod, httpBody, requestUriIdentifier, httpAuthorizationHeader, defaultAllowedAuthenticationCodeTypes, defaultAllowedStates);
     }
@@ -149,7 +148,7 @@ public abstract class PowerAuthAuthenticationProviderBase {
     }
 
     /**
-     * The same as {@link #validateRequestAuthentication(HttpServletRequest, String, String, List, List)} but uses default accepted authentication code type (2FA or 3FA) and does not specify forced authentication version.
+     * The same as {@link #validateRequestAuthentication(HttpServletRequest, String, String, List, List)} but uses default accepted authentication code types (any 2FA) and does not specify forced authentication version.
      * @param servletRequest HTTPServletRequest with signed data.
      * @param requestUriIdentifier Request URI identifier.
      * @param httpAuthorizationHeader PowerAuth HTTP authorization header.
@@ -160,7 +159,6 @@ public abstract class PowerAuthAuthenticationProviderBase {
         List<PowerAuthCodeType> defaultAllowedAuthenticationCodeTypes = new ArrayList<>();
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_BIOMETRY);
-        defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
         final List<ActivationStatus> defaultAllowedStates = Collections.singletonList(ActivationStatus.ACTIVE);
         return this.validateRequestAuthentication(servletRequest, requestUriIdentifier, httpAuthorizationHeader, defaultAllowedAuthenticationCodeTypes, defaultAllowedStates);
     }
@@ -175,7 +173,6 @@ public abstract class PowerAuthAuthenticationProviderBase {
         List<PowerAuthCodeType> defaultAllowedAuthenticationCodeTypes = new ArrayList<>();
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE);
         defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_BIOMETRY);
-        defaultAllowedAuthenticationCodeTypes.add(PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY);
         return this.validateToken(tokenHeader, defaultAllowedAuthenticationCodeTypes);
     }
 

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/SignatureController.java
@@ -60,8 +60,7 @@ public class SignatureController {
     @PowerAuth(resourceId = "/pa/signature/validate", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public Response validateSignature(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
         logger.info("action: validateSignature, state: initiated, activationId: {}",

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v3/TokenController.java
@@ -75,8 +75,7 @@ public class TokenController {
     @PowerAuth(resourceId = "/pa/token/create", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public EciesEncryptedResponse createToken(@RequestBody EciesEncryptedRequest request,
                                               PowerAuthApiAuthentication auth)
@@ -108,8 +107,7 @@ public class TokenController {
     @PowerAuth(resourceId = "/pa/token/remove", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public ObjectResponse<TokenRemoveResponse> removeToken(@Valid @RequestBody ObjectRequest<TokenRemoveRequest> request,
                                                            PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/AuthenticationController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/AuthenticationController.java
@@ -57,8 +57,7 @@ public class AuthenticationController {
     @PowerAuth(resourceId = "/pa/auth/validate", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public Response validateAuthentication(PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {
         logger.info("action: validateAuthentication, state: initiated, activationId: {}",

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/TokenController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/TokenController.java
@@ -72,8 +72,7 @@ public class TokenController {
     @PowerAuth(resourceId = "/pa/token/create", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public AeadEncryptedResponse createToken(@RequestBody AeadEncryptedRequest request,
                                              PowerAuthApiAuthentication auth)
@@ -105,8 +104,7 @@ public class TokenController {
     @PowerAuth(resourceId = "/pa/token/remove", authenticationCodeType = {
             PowerAuthCodeType.POSSESSION,
             PowerAuthCodeType.POSSESSION_KNOWLEDGE,
-            PowerAuthCodeType.POSSESSION_BIOMETRY,
-            PowerAuthCodeType.POSSESSION_KNOWLEDGE_BIOMETRY
+            PowerAuthCodeType.POSSESSION_BIOMETRY
     })
     public ObjectResponse<TokenRemoveResponse> removeToken(@Valid @RequestBody ObjectRequest<TokenRemoveRequest> request,
                                                            PowerAuthApiAuthentication auth) throws PowerAuthAuthenticationException {


### PR DESCRIPTION
Remove use of `KNOWLEDGE`, `BIOMETRY` and `POSSESSION_KNOWLEDGE_BIOMETRY` factors.