### PR TITLE
fix #709: register lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -171,6 +172,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven-jar-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description

Registered Lombok as an explicit annotation processor in the Maven compiler plugin configuration.

The project already depends on Lombok, but the compiler plugin did not explicitly list Lombok under annotation processor paths. This change adds the processor configuration to the root `pom.xml` while preserving the existing source, jar, javadoc, deploy, enforcer, and publishing plugin setup.

This repository manages Maven plugin versions explicitly, so the compiler plugin version is also declared as a property to avoid Maven missing-version warnings.

## Motivation and Context

Starting with JDK 23, annotation processor discovery is disabled by default. As a result, projects that rely on implicit Lombok discovery can fail to compile on Java 25 because Lombok-generated members are not available to `javac`.

This repository is tracked under the Java 25 / Lombok compatibility epic. Explicitly registering Lombok keeps local Java 25 compilation working and aligns the build with the approach used in the related repositories.

## Testing

The project compiles successfully with tests skipped:

```bash
mvn -DskipTests compile
```

Closes #709
