### PR TITLE
Fix #715: Return unblock timestamp for activations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,4 +2,5 @@
 
 ## 2.2.0
 - [#705](https://github.com/wultra/powerauth-restful-integration/issues/705) - Migrated to Spring Boot 4 and Jackson 3.
+- [#715](https://github.com/wultra/powerauth-restful-integration/issues/715) - Return unblock timestamp for activations.
 

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
@@ -38,6 +38,11 @@ public class ActivationStatusResponse {
     private String activationStatus;
 
     /**
+     * Timestamp of block expiration, null if temporary block is not in effect.
+     */
+    private Long timestampBlockExpire;
+
+    /**
      * Custom associated object.
      */
     private Map<String, Object> customObject;

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ActivationStatusResponse.java
@@ -38,7 +38,7 @@ public class ActivationStatusResponse {
     private String activationStatus;
 
     /**
-     * Timestamp of block expiration, null if temporary block is not in effect.
+     * Timestamp of block expiration in milliseconds since Unix epoch, null if temporary block is not in effect.
      */
     private Long timestampBlockExpire;
 

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
@@ -442,8 +442,8 @@ public class ActivationService {
             final ActivationStatusResponse response = new ActivationStatusResponse();
             response.setActivationStatus(paResponse.getStatusBlob());
 
-            final Long timestampBlockExpire = paResponse.getTimestampBlockExpire() != null ? paResponse.getTimestampBlockExpire().getTime() : null;
-            response.setTimestampBlockExpire(timestampBlockExpire);
+            final Date timestampBlockExpireDate = paResponse.getTimestampBlockExpire();
+            response.setTimestampBlockExpire(timestampBlockExpireDate != null ? timestampBlockExpireDate.getTime() : null);
             if (applicationConfiguration != null) {
                 final ActivationContext activationContext = activationContextConverter.fromActivationDetailResponse(paResponse);
                 response.setCustomObject(applicationConfiguration.statusServiceCustomObject(activationContext));

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ActivationService.java
@@ -441,6 +441,9 @@ public class ActivationService {
             );
             final ActivationStatusResponse response = new ActivationStatusResponse();
             response.setActivationStatus(paResponse.getStatusBlob());
+
+            final Long timestampBlockExpire = paResponse.getTimestampBlockExpire() != null ? paResponse.getTimestampBlockExpire().getTime() : null;
+            response.setTimestampBlockExpire(timestampBlockExpire);
             if (applicationConfiguration != null) {
                 final ActivationContext activationContext = activationContextConverter.fromActivationDetailResponse(paResponse);
                 response.setCustomObject(applicationConfiguration.statusServiceCustomObject(activationContext));


### PR DESCRIPTION
Addition of `timestampBlockExpire` with timestamp of block expiration, in case it is present. The flag is `null` in case temporary block is not in effect.