### PR TITLE
Fix #714: Add secure configuration endpoints for the mobile SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project are documented in this file, following the
 [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
 
-## 2.2.0 (TBA)
+## [Unreleased]
 ### Added
 - Return unblock timestamp for activations [(#715)](https://github.com/wultra/powerauth-restful-integration/issues/715)
 - Added secure configuration endpoints for the mobile SDK [(#714)](https://github.com/wultra/powerauth-restful-integration/issues/714)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file, following the
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
+
+## 2.2.0 (TBA)
+### Added
+- Return unblock timestamp for activations [(#715)](https://github.com/wultra/powerauth-restful-integration/issues/715)
+- Added secure configuration endpoints for the mobile SDK [(#714)](https://github.com/wultra/powerauth-restful-integration/issues/714)
+
+### Changed
+- Migrate to Spring Boot 4 and Jackson 3 [(#705)](https://github.com/wultra/powerauth-restful-integration/issues/705)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project are documented in this file, following the
 [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
 
 ## [Unreleased]
+
 ### Added
+
 - Return unblock timestamp for activations [(#715)](https://github.com/wultra/powerauth-restful-integration/issues/715)
 - Added secure configuration endpoints for the mobile SDK [(#714)](https://github.com/wultra/powerauth-restful-integration/issues/714)
 
 ### Changed
+
 - Migrate to Spring Boot 4 and Jackson 3 [(#705)](https://github.com/wultra/powerauth-restful-integration/issues/705)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,0 @@
-# Changelog
-
-## 2.2.0
-- [#705](https://github.com/wultra/powerauth-restful-integration/issues/705) - Migrated to Spring Boot 4 and Jackson 3.
-- [#715](https://github.com/wultra/powerauth-restful-integration/issues/715) - Return unblock timestamp for activations.
-

--- a/docs/Error-Codes.md
+++ b/docs/Error-Codes.md
@@ -36,6 +36,7 @@ The PowerAuth RESTful Integration library returns a uniform JSON error response 
 | `ERR_TEMPORARY_KEY`   | `POWER_AUTH_TEMPORARY_KEY_FAILURE`   | `PowerAuthTemporaryKeyException` | Issuing or validating a temporary encryption key failed.                               |
 | `ERR_PASSWORD_CHANGE` | `POWER_AUTH_PASSWORD_CHANGE_FAILURE` | `PowerAuthPasswordException`     | Knowledge-factor change failed.                                                        |
 | `ERR_BIOMETRY`        | `POWER_AUTH_BIOMETRY_FAILURE`        | `PowerAuthBiometryException`     | Biometric factor enrollment / removal failed.                                          |
+| `ERR_CONFIG`          | `POWER_AUTH_CONFIG_FAILURE`          | `PowerAuthConfigException`       | The request to fetch secure configuration from the server failed.                      |
 | `ERR_USER_INFO`       | `POWER_AUTH_USER_INFO_ERROR`         | `PowerAuthUserInfoException`     | The `UserInfoProvider` failed or the user-info endpoint could not assemble the claims. |
 | `ERR_STATUS`          | `POWER_AUTH_STATUS_ERROR`            | `PowerAuthStatusException`       | Server status / activation status query failed.                                        |
 

--- a/docs/RESTful-API-Methods.md
+++ b/docs/RESTful-API-Methods.md
@@ -1,0 +1,793 @@
+# PowerAuth RESTful API Methods
+
+This document lists all REST endpoints exposed by the `powerauth-restful-security-spring` module, with full request and response object schemas. Endpoints are grouped by resource area and ordered by protocol version. v4 is the current version; v3 endpoints are kept for backward compatibility.
+
+Responses that use the Wultra envelope are wrapped in `ObjectResponse<T>` with a top-level `status` (`"OK"`) and a `responseObject` field. An empty success response uses the `Response` type (just `status`).
+
+For error code details see [Error Codes](Error-Codes.md).
+
+---
+
+## Status
+
+### `POST /pa/v3/status`
+
+Returns application status information.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** none
+- **Request body:** none
+
+**Response** `ObjectResponse<ServerStatusResponse>`:
+
+| Field                 | Type     | Description                                           |
+|-----------------------|----------|-------------------------------------------------------| 
+| `serverTime`          | `long`   | Current server time in milliseconds since Unix epoch. |
+| `application.name`    | `String` | Application name from build properties.               |
+| `application.version` | `String` | Application version from build properties.            |
+
+
+---
+
+### `POST /pa/v4/status`
+
+Returns application status information. Extended to accept an optional application key for filtering supported algorithms.
+
+- **Protocol versions:** 4.0
+- **Authentication:** none
+
+**Request** `ObjectRequest<ServerStatusRequest>`:
+
+| Field            | Type     | Description                                                  |
+|------------------|----------|--------------------------------------------------------------| 
+| `applicationKey` | `String` | _(optional)_ Application key to filter supported algorithms. |
+
+**Response** `ObjectResponse<ServerStatusResponse>`:
+
+| Field                 | Type           | Description                                            |
+|-----------------------|----------------|--------------------------------------------------------| 
+| `serverTime`          | `long`         | Current server time in milliseconds since Unix epoch.  |
+| `supportedAlgorithms` | `List<String>` | List of supported cryptographic algorithm identifiers. |
+| `application.name`    | `String`       | Application name from build properties.                |
+| `application.version` | `String`       | Application version from build properties.             |
+
+
+| Error Code       | When                                          |
+|------------------|-----------------------------------------------|
+| `ERR_VALIDATION` | `applicationKey` field fails bean validation. |
+---
+
+## Key Store (Temporary Keys)
+
+### `POST /pa/v3/keystore/create`
+### `POST /pa/v4/keystore/create`
+
+Fetches a temporary encryption key encoded as a signed JWT. v3 uses ECIES; v4 uses AEAD.
+
+- **Protocol versions:** 3.3 (v3), 4.0 (v4)
+- **Authentication:** none
+
+**Request** `ObjectRequest<TemporaryKeyRequest>`:
+
+| Field | Type     | Required | Description                                                    |
+|-------|----------|----------|----------------------------------------------------------------|
+| `jwt` | `String` | ✓        | JWT-encoded temporary key request (device public key + nonce). |
+
+**Response** `ObjectResponse<TemporaryKeyResponse>`:
+
+| Field | Type     | Description                                                         |
+|-------|----------|---------------------------------------------------------------------|
+| `jwt` | `String` | JWT-encoded temporary key response (server public key + signature). |
+
+
+| Error Code          | When                              |
+|---------------------|-----------------------------------|
+| `ERR_TEMPORARY_KEY` | Issuing the temporary key failed. |
+| `ERR_VALIDATION`    | `jwt` field is blank.             |
+---
+
+## Activation
+
+### `POST /pa/v3/activation/create`
+
+Creates a new activation. The outer body is ECIES-encrypted in `APPLICATION_SCOPE`; the inner `activationData` field carries a further ECIES-encrypted layer 2 payload — see [Activation Layer 2 Schemas](#activation-layer-2-schemas).
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** none (application-scope encryption)
+
+**Request** `ActivationLayer1Request` (decrypted from ECIES):
+
+| Field                | Type                    | Required | Description                                                           |
+|----------------------|-------------------------|----------|-----------------------------------------------------------------------|
+| `type`               | `ActivationType`        | ✓        | Activation type: `CODE`, `CUSTOM`, or `RECOVERY`.                     |
+| `identityAttributes` | `Map<String, String>`   | ✓        | Activation-type-specific identity attributes (e.g. `code`, `otp`).    |
+| `customAttributes`   | `Map<String, Object>`   |          | Optional custom attributes passed to `CustomActivationProvider`.      |
+| `activationData`     | `EciesEncryptedRequest` | ✓        | ECIES-encrypted layer 2 payload — see `ActivationLayer2Request (v3)`. |
+
+**Response** `ActivationLayer1Response` (re-encrypted by ECIES):
+
+| Field              | Type                     | Description                                                             |
+|--------------------|--------------------------|-------------------------------------------------------------------------|
+| `activationData`   | `EciesEncryptedResponse` | ECIES-encrypted layer 2 response — see `ActivationLayer2Response (v3)`. |
+| `customAttributes` | `Map<String, Object>`    | Custom attributes returned by `CustomActivationProvider`.               |
+| `userInfo`         | `Map<String, Object>`    | OIDC claims returned by `UserInfoProvider` (may be `null`).             |
+
+
+| Error Code       | When                                                   |
+|------------------|--------------------------------------------------------|
+| `ERR_ENCRYPTION` | Encryption context missing or ECIES decryption failed. |
+| `ERR_VALIDATION` | Required fields missing or invalid.                    |
+---
+
+### `POST /pa/v3/activation/status`
+
+Returns the current activation status.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** none
+
+**Request** `ObjectRequest<ActivationStatusRequest>`:
+
+| Field          | Type     | Required | Description                                          |
+|----------------|----------|----------|------------------------------------------------------|
+| `activationId` | `String` | ✓        | Activation ID.                                       |
+| `challenge`    | `String` |          | 16-byte Base64 challenge for status blob encryption. |
+
+**Response** `ObjectResponse<ActivationStatusResponse>`:
+
+| Field                 | Type                  | Description                                             |
+|-----------------------|-----------------------|---------------------------------------------------------|
+| `activationId`        | `String`              | Activation ID.                                          |
+| `encryptedStatusBlob` | `String`              | Encrypted activation status blob (Base64).              |
+| `nonce`               | `String`              | Nonce used for status blob encryption (Base64).         |
+| `customObject`        | `Map<String, Object>` | Custom object from `PowerAuthApplicationConfiguration`. |
+
+
+| Error Code       | When                    |
+|------------------|-------------------------|
+| `ERR_VALIDATION` | `activationId` is null. |
+---
+
+### `POST /pa/v3/activation/remove`
+
+Removes an activation. Requires a PowerAuth signature.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** `X-PowerAuth-Authorization` header — `POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY` (or `POSSESSION` when `activation.remove.allow1fa=true`)
+- **Request body:** none
+
+**Response** `ObjectResponse<ActivationRemoveResponse>`:
+
+| Field          | Type     | Description                   |
+|----------------|----------|-------------------------------| 
+| `activationId` | `String` | ID of the removed activation. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Activation removal failed on the server.                    |
+---
+
+### `POST /pa/v3/activation/detail`
+
+Returns the detail of the authenticated activation. Token-authenticated, response encrypted.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** PowerAuth token (`POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY`)
+- **Request body:** none (encrypted via `ACTIVATION_SCOPE`)
+
+**Response** `ObjectResponse<ActivationDetailResponse>` (encrypted):
+
+| Field            | Type     | Description                     |
+|------------------|----------|---------------------------------| 
+| `activationId`   | `String` | Activation ID.                  |
+| `activationName` | `String` | Human-readable activation name. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Activation detail query failed on the server.               |
+---
+
+### `POST /pa/v3/activation/rename`
+
+Renames an activation. Signature-authenticated, response encrypted.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** PowerAuth signature (`POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY`, resourceId `/pa/activation/rename`)
+
+**Request** `ActivationRenameRequest`:
+
+| Field            | Type     | Required | Description                 |
+|------------------|----------|----------|-----------------------------|
+| `activationName` | `String` | ✓        | New name for the activation |. |
+
+**Response** `ObjectResponse<ActivationDetailResponse>` (encrypted):
+
+| Field            | Type     | Description              |
+|------------------|----------|--------------------------| 
+| `activationId`   | `String` | Activation ID.           |
+| `activationName` | `String` | Updated activation name. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Rename operation failed on the server.                      |
+| `ERR_VALIDATION`     | `activationName` is blank.                                  |
+---
+
+### `POST /pa/v4/activation/create`
+
+Creates a new activation. The outer body is AEAD-encrypted in `APPLICATION_SCOPE`; the inner `activationData` field carries a further AEAD-encrypted layer 2 payload — see [Activation Layer 2 Schemas](#activation-layer-2-schemas).
+
+- **Protocol versions:** 4.0
+- **Authentication:** none (application-scope encryption)
+
+**Request** `ActivationLayer1Request` (decrypted from AEAD):
+
+| Field                | Type                   | Required | Description                                                          |
+|----------------------|------------------------|----------|----------------------------------------------------------------------|
+| `type`               | `ActivationType`       | ✓        | Activation type: `CODE`, `CUSTOM`, or `RECOVERY`.                    |
+| `identityAttributes` | `Map<String, String>`  | ✓        | Activation-type-specific identity attributes.                        |
+| `customAttributes`   | `Map<String, Object>`  |          | Optional custom attributes passed to `CustomActivationProvider`.     |
+| `activationData`     | `AeadEncryptedRequest` | ✓        | AEAD-encrypted layer 2 payload — see `ActivationLayer2Request (v4)`. |
+
+**Response** `ActivationLayer1Response` (re-encrypted by AEAD):
+
+| Field              | Type                    | Description                                                            |
+|--------------------|-------------------------|------------------------------------------------------------------------|
+| `activationData`   | `AeadEncryptedResponse` | AEAD-encrypted layer 2 response — see `ActivationLayer2Response (v4)`. |
+| `customAttributes` | `Map<String, Object>`   | Custom attributes returned by `CustomActivationProvider`.              |
+| `userInfo`         | `Map<String, Object>`   | OIDC claims returned by `UserInfoProvider` (may be `null`).            |
+
+
+| Error Code       | When                                                  |
+|------------------|-------------------------------------------------------|
+| `ERR_ENCRYPTION` | Encryption context missing or AEAD decryption failed. |
+| `ERR_VALIDATION` | Required fields missing or invalid.                   |
+---
+
+### `POST /pa/v4/activation/status`
+
+Returns the current activation status. Both request and response body are AEAD-encrypted in `ACTIVATION_SCOPE`. Allowed activation states: `ACTIVE`, `PENDING_COMMIT`, `BLOCKED`, `REMOVED`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** none (activation-scope encryption)
+
+**Request** `ActivationStatusRequest` (decrypted from AEAD): _(empty — activation is identified by the AEAD context)_
+
+**Response** `ActivationStatusResponse` (re-encrypted by AEAD):
+
+| Field                  | Type                  | Description                                                                                |
+|------------------------|-----------------------|--------------------------------------------------------------------------------------------|
+| `activationStatus`     | `String`              | Activation status: `CREATED`, `PENDING_COMMIT`, `ACTIVE`, `BLOCKED`, or `REMOVED`.         |
+| `timestampBlockExpire` | `Long`                | Expiration of a temporary block in ms since Unix epoch; `null` if not temporarily blocked. |
+| `customObject`         | `Map<String, Object>` | Custom object from `PowerAuthApplicationConfiguration`.                                    |
+
+
+| Error Code       | When                                                  |
+|------------------|-------------------------------------------------------|
+| `ERR_ENCRYPTION` | Encryption context missing or AEAD decryption failed. |
+---
+
+### `POST /pa/v4/activation/remove`
+
+Removes an activation. Requires a PowerAuth signature.
+
+- **Protocol versions:** 4.0
+- **Authentication:** `X-PowerAuth-Authorization` header — `POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY` (or `POSSESSION` when `activation.remove.allow1fa=true`)
+- **Request body:** none
+
+**Response** `ObjectResponse<ActivationRemoveResponse>`:
+
+| Field          | Type     | Description                   |
+|----------------|----------|-------------------------------|
+| `activationId` | `String` | ID of the removed activation. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Activation removal failed on the server.                    |
+---
+
+### `POST /pa/v4/activation/detail`
+
+Returns the detail of the authenticated activation. Token-authenticated, response encrypted.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth token (`POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY`)
+- **Request body:** none (encrypted via `ACTIVATION_SCOPE`)
+
+**Response** `ObjectResponse<ActivationDetailResponse>` (encrypted):
+
+| Field            | Type     | Description                     |
+|------------------|----------|---------------------------------| 
+| `activationId`   | `String` | Activation ID.                  |
+| `activationName` | `String` | Human-readable activation name. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Activation detail query failed on the server.               |
+---
+
+### `POST /pa/v4/activation/rename`
+
+Renames an activation. Signature-authenticated, response encrypted.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature (`POSSESSION_KNOWLEDGE` or `POSSESSION_BIOMETRY`, resourceId `/pa/activation/rename`)
+
+**Request** `ActivationRenameRequest`:
+
+| Field            | Type     | Required | Description                  |
+|------------------|----------|----------|------------------------------|
+| `activationName` | `String` | ✓        | New name for the activation. |
+
+**Response** `ObjectResponse<ActivationDetailResponse>` (encrypted):
+
+| Field            | Type     | Description              |
+|------------------|----------|--------------------------| 
+| `activationId`   | `String` | Activation ID.           |
+| `activationName` | `String` | Updated activation name. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Rename operation failed on the server.                      |
+| `ERR_VALIDATION`     | `activationName` is blank.                                  |
+---
+
+### `POST /pa/v4/activation/confirm`
+
+Confirms an activation and optionally enables biometry. Requires `POSSESSION_KNOWLEDGE` signature. Allowed activation states: `ACTIVE`, `PENDING_COMMIT`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature (`POSSESSION_KNOWLEDGE`, resourceId `/pa/activation/confirm`)
+
+**Request** `ObjectRequest<ActivationConfirmRequest>`:
+
+| Field            | Type      | Required | Description                                                         |
+|------------------|-----------|----------|---------------------------------------------------------------------|
+| `enableBiometry` | `boolean` |          | Whether to enable biometric authentication factor. Default `false`. |
+
+**Response:** `Response` (empty success — just `status: "OK"`)
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_ACTIVATION`     | Confirm operation failed on the server.                     |
+---
+
+## Authentication / Signature Validation
+
+### `GET|POST|PUT|DELETE /pa/v3/signature/validate`
+
+Validates a PowerAuth signature on any request body.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** `X-PowerAuth-Authorization` header — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/signature/validate`
+- **Request body:** any (included in the signed data)
+- **Response:** `Response` (empty success)
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+---
+
+### `GET|POST|PUT|DELETE /pa/v4/auth/validate`
+
+Validates a PowerAuth authentication code on any request body.
+
+- **Protocol versions:** 4.0
+- **Authentication:** `X-PowerAuth-Authorization` header — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/auth/validate`
+- **Request body:** any (included in the signed data)
+- **Response:** `Response` (empty success)
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+---
+
+## Token-Based Authentication
+
+### `POST /pa/v3/token/create`
+
+Creates a simple authentication token. Request and response are ECIES-encrypted.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** PowerAuth signature — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/token/create`
+- **Request body:** `EciesEncryptedRequest` _(opaque, encrypted by the client SDK)_
+- **Response:** `EciesEncryptedResponse` _(opaque, decrypted by the client SDK; contains token ID and token secret)_
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_AUTHENTICATION` | Request body is null (`POWER_AUTH_REQUEST_INVALID`).        |
+---
+
+### `POST /pa/v3/token/remove`
+
+Removes a simple authentication token.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** PowerAuth signature — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/token/remove`
+
+**Request** `ObjectRequest<TokenRemoveRequest>`:
+
+| Field     | Type     | Required | Description                |
+|-----------|----------|----------|----------------------------|
+| `tokenId` | `String` | ✓        | ID of the token to remove. |
+
+**Response** `ObjectResponse<TokenRemoveResponse>`:
+
+| Field     | Type     | Description              |
+|-----------|----------|--------------------------| 
+| `tokenId` | `String` | ID of the removed token. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_VALIDATION`     | `tokenId` is blank.                                         |
+---
+
+### `POST /pa/v4/token/create`
+
+Creates a simple authentication token. Request and response are AEAD-encrypted.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/token/create`
+- **Request body:** `AeadEncryptedRequest` _(opaque, encrypted by the client SDK)_
+- **Response:** `AeadEncryptedResponse` _(opaque, decrypted by the client SDK; contains token ID and token secret)_
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_AUTHENTICATION` | Request body is null (`POWER_AUTH_REQUEST_INVALID`).        |
+---
+
+### `POST /pa/v4/token/remove`
+
+Removes a simple authentication token.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION`, `POSSESSION_KNOWLEDGE`, or `POSSESSION_BIOMETRY`; resourceId `/pa/token/remove`
+
+**Request** `ObjectRequest<TokenRemoveRequest>`:
+
+| Field     | Type     | Required | Description               |
+|-----------|----------|----------|---------------------------|
+| `tokenId` | `String` | ✓        | ID of the token to remove. |
+
+**Response** `ObjectResponse<TokenRemoveResponse>`:
+
+| Field     | Type     | Description              |
+|-----------|----------|--------------------------| 
+| `tokenId` | `String` | ID of the removed token. |
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_VALIDATION`     | `tokenId` is blank.                                         |
+---
+
+## Secure Vault
+
+### `POST /pa/v3/vault/unlock`
+
+Unlocks the secure vault. The HTTP body is an `EciesEncryptedRequest`; the decrypted payload is `VaultUnlockRequestPayload`. The HTTP response is an `EciesEncryptedResponse`; the decrypted payload is `VaultUnlockResponsePayload`.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3
+- **Authentication:** `X-PowerAuth-Authorization` header (any factor combination)
+
+**Request payload** `VaultUnlockRequestPayload` (inside `EciesEncryptedRequest`):
+
+| Field    | Type     | Description                                          |
+|----------|----------|------------------------------------------------------| 
+| `reason` | `String` | _(optional)_ Human-readable reason for vault unlock. |
+
+**Response payload** `VaultUnlockResponsePayload` (inside `EciesEncryptedResponse`):
+
+| Field                         | Type     | Description                              |
+|-------------------------------|----------|------------------------------------------| 
+| `encryptedVaultEncryptionKey` | `String` | Encrypted vault encryption key (Base64). |
+
+
+| Error Code           | When                                                          |
+|----------------------|---------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or header is malformed. |
+| `ERR_SECURE_VAULT`   | Vault unlock failed on the server.                            |
+---
+
+### `POST /pa/v4/vault/unlock`
+
+Unlocks the secure vault. The HTTP body is an `AeadEncryptedRequest`; the decrypted payload is `VaultUnlockRequestPayload`. The HTTP response is an `AeadEncryptedResponse`; the decrypted payload is `VaultUnlockResponsePayload`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** `X-PowerAuth-Authorization` header (any factor combination)
+
+**Request payload** `VaultUnlockRequestPayload` (inside `AeadEncryptedRequest`):
+
+| Field           | Type     | Required | Description                                          |
+|-----------------|----------|----------|------------------------------------------------------|
+| `keyIdentifier` | `String` | ✓        | Identifier of the key to unlock.                     |
+| `reason`        | `String` |          | _(optional)_ Human-readable reason for vault unlock. |
+
+**Response payload** `VaultUnlockResponsePayload` (inside `AeadEncryptedResponse`):
+
+| Field                | Type     | Description                    |
+|----------------------|----------|--------------------------------| 
+| `vaultEncryptionKey` | `String` | Vault encryption key (Base64). |
+
+
+| Error Code           | When                                                          |
+|----------------------|---------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or header is malformed. |
+| `ERR_SECURE_VAULT`   | Vault unlock failed on the server.                            |
+| `ERR_VALIDATION`     | `keyIdentifier` is blank.                                     |
+---
+
+## Biometry
+
+### `POST /pa/v4/biometry/add`
+
+Sets up biometric authentication. Request and response are AEAD-encrypted.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION_KNOWLEDGE`; resourceId `/pa/biometry/add`
+- **Request body:** `AeadEncryptedRequest` _(opaque, encrypted by the client SDK; contains biometry factor key material)_
+- **Response:** `AeadEncryptedResponse` _(opaque, decrypted by the client SDK)_
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_BIOMETRY`       | Biometry setup failed on the server.                        |
+---
+
+### `POST /pa/v4/biometry/remove`
+
+Removes biometric authentication.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION`; resourceId `/pa/biometry/remove`
+- **Request body:** none
+- **Response:** `Response` (empty success)
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_BIOMETRY`       | Biometry removal failed on the server.                      |
+---
+
+## Password
+
+### `POST /pa/v4/password/change`
+
+Changes the knowledge factor (password / PIN). Request and response are AEAD-encrypted.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION_KNOWLEDGE`; resourceId `/pa/password/change`
+- **Request body:** `AeadEncryptedRequest` _(opaque, encrypted by the client SDK; contains old and new password data)_
+- **Response:** `AeadEncryptedResponse` _(opaque, decrypted by the client SDK)_
+
+
+| Error Code            | When                                                        |
+|-----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION`  | Authentication code validation failed or wrong factor type. |
+| `ERR_PASSWORD_CHANGE` | Password change failed on the server.                       |
+---
+
+## Protocol Upgrade
+
+### `POST /pa/v4/upgrade/start`
+
+Starts the upgrade of an activation from protocol v3 to v4. Requires both `X-PowerAuth-Authorization` and `X-PowerAuth-Encryption` headers. The HTTP body is an `AeadEncryptedRequest`; the decrypted payload is `UpgradeRequestPayload`. The HTTP response is an `AeadEncryptedResponse`; the decrypted payload is `UpgradeResponsePayload`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** PowerAuth signature — `POSSESSION_KNOWLEDGE`; resourceId `/pa/upgrade/start`
+
+**Request payload** `UpgradeRequestPayload` (inside `AeadEncryptedRequest`):
+
+| Field                 | Type                  | Required | Description                                                        |
+|-----------------------|-----------------------|----------|--------------------------------------------------------------------|
+| `sharedSecretRequest` | `SharedSecretRequest` | ✓        | KEM shared-secret request (algorithm + encapsulation keys).        |
+| `devicePublicKeys`    | `DevicePublicKeys`    | ✓        | Device public keys for the upgraded protocol.                      |
+| `enableBiometry`      | `boolean`             |          | Whether biometry should be enabled after upgrade. Default `false`. |
+
+`SharedSecretRequest`:
+
+| Field               | Type           | Required | Description                                                           |
+|---------------------|----------------|----------|-----------------------------------------------------------------------|
+| `algorithm`         | `String`       | ✓        | KEM algorithm identifier.                                             |
+| `encapsulationKeys` | `List<String>` | ✓        | List of Base64-encoded client encapsulation keys (must not be empty). |
+
+`DevicePublicKeys`:
+
+| Field   | Type     | Required | Description                                                       |
+|---------|----------|----------|-------------------------------------------------------------------|
+| `ecdsa` | `String` | ✓        | Base64-encoded device ECDSA public key                            |.       |
+| `mldsa` | `String` |          | Base64-encoded device ML-DSA public key (optional, post-quantum). |
+
+**Response payload** `UpgradeResponsePayload` (inside `AeadEncryptedResponse`):
+
+| Field                  | Type                   | Description                                              |
+|------------------------|------------------------|----------------------------------------------------------|
+| `sharedSecretResponse` | `SharedSecretResponse` | KEM shared-secret response (salt + encapsulated keys).   |
+| `serverPublicKeys`     | `ServerPublicKeys`     | Server public keys for the upgraded protocol.            |
+| `ctrData`              | `String`               | Base64-encoded counter data for the upgraded activation. |
+
+`SharedSecretResponse`:
+
+| Field              | Type           | Description                                      |
+|--------------------|----------------|--------------------------------------------------| 
+| `salt`             | `String`       | Base64-encoded KEM salt.                         |
+| `encapsulatedKeys` | `List<String>` | List of Base64-encoded server-encapsulated keys. |
+
+`ServerPublicKeys`:
+
+| Field   | Type     | Description                                                            |
+|---------|----------|------------------------------------------------------------------------| 
+| `ecdsa` | `String` | Base64-encoded server ECDSA public key.                                |
+| `mldsa` | `String` | Base64-encoded server ML-DSA public key (post-quantum; may be `null`). |
+
+
+| Error Code           | When                                                                   |
+|----------------------|------------------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type.            |
+| `ERR_UPGRADE`        | Upgrade start failed (header invalid, version mismatch, server error). |
+| `ERR_VALIDATION`     | Required payload fields missing.                                       |
+---
+
+### `POST /pa/v4/upgrade/confirm`
+
+Confirms the upgrade of an activation from protocol v3 to v4.
+
+- **Protocol versions:** 4.0
+- **Authentication:** `X-PowerAuth-Authorization` header — `POSSESSION`; resourceId `/pa/upgrade/confirm`
+- **Request body:** none
+- **Response:** `Response` (empty success)
+
+
+| Error Code           | When                                                        |
+|----------------------|-------------------------------------------------------------|
+| `ERR_AUTHENTICATION` | Authentication code validation failed or wrong factor type. |
+| `ERR_UPGRADE`        | Upgrade confirmation failed (header invalid, server error). |
+---
+
+## User Info
+
+### `POST /pa/v3/user/info`
+### `POST /pa/v4/user/info`
+
+Returns OIDC-style user info claims for the authenticated activation owner. Both request and response are AEAD-encrypted in `ACTIVATION_SCOPE`. Served by the `UserInfoProvider` SPI.
+
+- **Protocol versions:** 3.0, 3.1, 3.2, 3.3, 4.0
+- **Authentication:** activation-scope encryption (activation must be valid)
+
+**Request** `UserInfoRequest` (decrypted from AEAD): _(empty — no selectable claims filtering at this time)_
+
+**Response** `Map<String, Object>` (re-encrypted by AEAD): OIDC standard claims. Common fields:
+
+| Claim          | Type     | Description                   |
+|----------------|----------|-------------------------------| 
+| `sub`          | `String` | Subject identifier (user ID). |
+| `name`         | `String` | Full name.                    |
+| `given_name`   | `String` | Given (first) name.           |
+| `family_name`  | `String` | Family name.                  |
+| `email`        | `String` | Email address.                |
+| `phone_number` | `String` | Phone number.                 |
+
+Additional claims may be provided by the application's `UserInfoProvider` implementation.
+
+
+| Error Code      | When                                            |
+|-----------------|-------------------------------------------------|
+| `ERR_USER_INFO` | `UserInfoProvider` failed or returned an error. |
+---
+
+## Secure Configuration
+
+### `POST /pa/v4/config/application`
+
+Fetches configuration items visible in the **application scope** (non-personalized, shared by all activations). The request and response body are AEAD-encrypted in `APPLICATION_SCOPE`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** none (application-scope encryption)
+- **Request body:** empty encrypted body
+
+**Response** `ConfigResponse` (re-encrypted by AEAD):
+
+| Field    | Type               | Description                  |
+|----------|--------------------|------------------------------|
+| `config` | `List<ConfigItem>` | List of configuration items. |
+
+`ConfigItem`:
+
+| Field   | Type          | Description                                            |
+|---------|---------------|--------------------------------------------------------| 
+| `key`   | `String`      | Configuration item key.                                |
+| `value` | `Object`      | Configuration item value; a scalar or a nested object. |
+| `scope` | `ConfigScope` | Scope: `APPLICATION` or `ACTIVATION`.                  |
+
+
+| Error Code   | When                                              |
+|--------------|---------------------------------------------------|
+| `ERR_CONFIG` | Configuration fetch from PowerAuth Server failed. |
+---
+
+### `POST /pa/v4/config/activation`
+
+Fetches configuration items visible in the **activation scope** (personalized, post-activation). The request and response body are AEAD-encrypted in `ACTIVATION_SCOPE`.
+
+- **Protocol versions:** 4.0
+- **Authentication:** activation-scope encryption (activation must be valid)
+- **Request body:** empty encrypted body
+
+**Response** `ConfigResponse` (re-encrypted by AEAD): same structure as above. May include items of both `APPLICATION` and `ACTIVATION` scope.
+
+
+| Error Code   | When                                              |
+|--------------|---------------------------------------------------|
+| `ERR_CONFIG` | Configuration fetch from PowerAuth Server failed. |
+---
+
+## Activation Layer 2 Schemas
+
+The `activationData` field in `ActivationLayer1Request` / `ActivationLayer1Response` carries a second encrypted envelope whose plaintext is the layer 2 request/response object. These are produced and consumed by the client SDK; the server decrypts and re-encrypts them internally.
+
+### `ActivationLayer2Request` (v3, inside `EciesEncryptedRequest`)
+
+| Field             | Type     | Description                                                               |
+|-------------------|----------|---------------------------------------------------------------------------| 
+| `devicePublicKey` | `String` | Base64-encoded device public key.                                         |
+| `activationOtp`   | `String` | _(optional)_ Additional activation OTP for extra-factor activation types. |
+| `activationName`  | `String` | _(optional)_ Human-readable name for the activation.                      |
+| `extras`          | `String` | _(optional)_ Arbitrary extra data stored with the activation.             |
+| `platform`        | `String` | _(optional)_ User device platform (e.g. `ios`, `android`).                |
+| `deviceInfo`      | `String` | _(optional)_ Human-readable device model / OS information.                |
+
+### `ActivationLayer2Response` (v3, inside `EciesEncryptedResponse`)
+
+| Field             | Type     | Description                          |
+|-------------------|----------|--------------------------------------| 
+| `activationId`    | `String` | Assigned activation ID (UUID).       |
+| `serverPublicKey` | `String` | Base64-encoded server public key.    |
+| `ctrData`         | `String` | Base64-encoded initial counter data. |
+
+---
+
+### `ActivationLayer2Request` (v4, inside `AeadEncryptedRequest`)
+
+| Field                 | Type                  | Required | Description                                                   |
+|-----------------------|-----------------------|----------|---------------------------------------------------------------|
+| `sharedSecretRequest` | `SharedSecretRequest` |          | KEM shared-secret request — see `SharedSecretRequest` above.  |
+| `devicePublicKeys`    | `DevicePublicKeys`    |          | Device public keys — see `DevicePublicKeys` above.            |
+| `activationOtp`       | `String`              |          | _(optional)_ Additional activation OTP.                       |
+| `activationName`      | `String`              |          | _(optional)_ Human-readable name for the activation.          |
+| `extras`              | `String`              |          | _(optional)_ Arbitrary extra data stored with the activation. |
+| `platform`            | `String`              |          | _(optional)_ User device platform (e.g. `ios`, `android`).    |
+| `deviceInfo`          | `String`              |          | _(optional)_ Human-readable device model / OS information.    |
+
+### `ActivationLayer2Response` (v4, inside `AeadEncryptedResponse`)
+
+| Field                  | Type                   | Description                                                    |
+|------------------------|------------------------|----------------------------------------------------------------|
+| `sharedSecretResponse` | `SharedSecretResponse` | KEM shared-secret response — see `SharedSecretResponse` above. |
+| `serverPublicKeys`     | `ServerPublicKeys`     | Server public keys — see `ServerPublicKeys` above.             |
+| `activationId`         | `String`               | Assigned activation ID (UUID).                                 |
+| `ctrData`              | `String`               | Base64-encoded initial counter data.                           |

--- a/docs/RESTful-API-Methods.md
+++ b/docs/RESTful-API-Methods.md
@@ -60,6 +60,9 @@ Returns application status information. Extended to accept an optional applicati
 ## Key Store (Temporary Keys)
 
 ### `POST /pa/v3/keystore/create`
+
+The same applies to version v3 as to version v4.
+
 ### `POST /pa/v4/keystore/create`
 
 Fetches a temporary encryption key encoded as a signed JWT. v3 uses ECIES; v4 uses AEAD.
@@ -672,6 +675,9 @@ Confirms the upgrade of an activation from protocol v3 to v4.
 ## User Info
 
 ### `POST /pa/v3/user/info`
+
+The same applies to version v3 as to version v4.
+
 ### `POST /pa/v4/user/info`
 
 Returns OIDC-style user info claims for the authenticated activation owner. Both request and response are AEAD-encrypted in `ACTIVATION_SCOPE`. Served by the `UserInfoProvider` SPI.

--- a/docs/RESTful-API-Methods.md
+++ b/docs/RESTful-API-Methods.md
@@ -38,9 +38,9 @@ Returns application status information. Extended to accept an optional applicati
 
 **Request** `ObjectRequest<ServerStatusRequest>`:
 
-| Field            | Type     | Description                                                  |
-|------------------|----------|--------------------------------------------------------------| 
-| `applicationKey` | `String` | _(optional)_ Application key to filter supported algorithms. |
+| Field            | Type     | Required | Description                                     |
+|------------------|----------|----------|-------------------------------------------------|
+| `applicationKey` | `String` |          | Application key to filter supported algorithms. |
 
 **Response** `ObjectResponse<ServerStatusResponse>`:
 
@@ -99,7 +99,7 @@ Creates a new activation. The outer body is ECIES-encrypted in `APPLICATION_SCOP
 
 | Field                | Type                    | Required | Description                                                           |
 |----------------------|-------------------------|----------|-----------------------------------------------------------------------|
-| `type`               | `ActivationType`        | ✓        | Activation type: `CODE`, `CUSTOM`, or `RECOVERY`.                     |
+| `type`               | `ActivationType`        | ✓        | Activation type: `CODE`, `DIRECT` (or deprecated alias `CUSTOM`).     |
 | `identityAttributes` | `Map<String, String>`   | ✓        | Activation-type-specific identity attributes (e.g. `code`, `otp`).    |
 | `customAttributes`   | `Map<String, Object>`   |          | Optional custom attributes passed to `CustomActivationProvider`.      |
 | `activationData`     | `EciesEncryptedRequest` | ✓        | ECIES-encrypted layer 2 payload — see `ActivationLayer2Request (v3)`. |
@@ -230,7 +230,7 @@ Creates a new activation. The outer body is AEAD-encrypted in `APPLICATION_SCOPE
 
 | Field                | Type                   | Required | Description                                                          |
 |----------------------|------------------------|----------|----------------------------------------------------------------------|
-| `type`               | `ActivationType`       | ✓        | Activation type: `CODE`, `CUSTOM`, or `RECOVERY`.                    |
+| `type`               | `ActivationType`       | ✓        | Activation type: `CODE`, `DIRECT` (or deprecated alias `CUSTOM`).    |
 | `identityAttributes` | `Map<String, String>`  | ✓        | Activation-type-specific identity attributes.                        |
 | `customAttributes`   | `Map<String, Object>`  |          | Optional custom attributes passed to `CustomActivationProvider`.     |
 | `activationData`     | `AeadEncryptedRequest` | ✓        | AEAD-encrypted layer 2 payload — see `ActivationLayer2Request (v4)`. |
@@ -495,9 +495,9 @@ Unlocks the secure vault. The HTTP body is an `EciesEncryptedRequest`; the decry
 
 **Request payload** `VaultUnlockRequestPayload` (inside `EciesEncryptedRequest`):
 
-| Field    | Type     | Description                                          |
-|----------|----------|------------------------------------------------------| 
-| `reason` | `String` | _(optional)_ Human-readable reason for vault unlock. |
+| Field    | Type     | Required | Description                             |
+|----------|----------|----------|-----------------------------------------|
+| `reason` | `String` |          | Human-readable reason for vault unlock. |
 
 **Response payload** `VaultUnlockResponsePayload` (inside `EciesEncryptedResponse`):
 
@@ -524,7 +524,7 @@ Unlocks the secure vault. The HTTP body is an `AeadEncryptedRequest`; the decryp
 | Field           | Type     | Required | Description                                          |
 |-----------------|----------|----------|------------------------------------------------------|
 | `keyIdentifier` | `String` | ✓        | Identifier of the key to unlock.                     |
-| `reason`        | `String` |          | _(optional)_ Human-readable reason for vault unlock. |
+| `reason`        | `String` |          | Human-readable reason for vault unlock.              |
 
 **Response payload** `VaultUnlockResponsePayload` (inside `AeadEncryptedResponse`):
 
@@ -752,14 +752,14 @@ The `activationData` field in `ActivationLayer1Request` / `ActivationLayer1Respo
 
 ### `ActivationLayer2Request` (v3, inside `EciesEncryptedRequest`)
 
-| Field             | Type     | Description                                                               |
-|-------------------|----------|---------------------------------------------------------------------------| 
-| `devicePublicKey` | `String` | Base64-encoded device public key.                                         |
-| `activationOtp`   | `String` | _(optional)_ Additional activation OTP for extra-factor activation types. |
-| `activationName`  | `String` | _(optional)_ Human-readable name for the activation.                      |
-| `extras`          | `String` | _(optional)_ Arbitrary extra data stored with the activation.             |
-| `platform`        | `String` | _(optional)_ User device platform (e.g. `ios`, `android`).                |
-| `deviceInfo`      | `String` | _(optional)_ Human-readable device model / OS information.                |
+| Field             | Type     | Required | Description                                                  |
+|-------------------|----------|----------|--------------------------------------------------------------|
+| `devicePublicKey` | `String` | ✓        | Base64-encoded device public key.                            |
+| `activationOtp`   | `String` |          | Additional activation OTP for extra-factor activation types. |
+| `activationName`  | `String` |          | Human-readable name for the activation.                      |
+| `extras`          | `String` |          | Arbitrary extra data stored with the activation.             |
+| `platform`        | `String` |          | User device platform (e.g. `ios`, `android`).                |
+| `deviceInfo`      | `String` |          | Human-readable device model / OS information.                |
 
 ### `ActivationLayer2Response` (v3, inside `EciesEncryptedResponse`)
 
@@ -777,11 +777,11 @@ The `activationData` field in `ActivationLayer1Request` / `ActivationLayer1Respo
 |-----------------------|-----------------------|----------|---------------------------------------------------------------|
 | `sharedSecretRequest` | `SharedSecretRequest` |          | KEM shared-secret request — see `SharedSecretRequest` above.  |
 | `devicePublicKeys`    | `DevicePublicKeys`    |          | Device public keys — see `DevicePublicKeys` above.            |
-| `activationOtp`       | `String`              |          | _(optional)_ Additional activation OTP.                       |
-| `activationName`      | `String`              |          | _(optional)_ Human-readable name for the activation.          |
-| `extras`              | `String`              |          | _(optional)_ Arbitrary extra data stored with the activation. |
-| `platform`            | `String`              |          | _(optional)_ User device platform (e.g. `ios`, `android`).    |
-| `deviceInfo`          | `String`              |          | _(optional)_ Human-readable device model / OS information.    |
+| `activationOtp`       | `String`              |          | Additional activation OTP.                                    |
+| `activationName`      | `String`              |          | Human-readable name for the activation.                       |
+| `extras`              | `String`              |          | Arbitrary extra data stored with the activation.              |
+| `platform`            | `String`              |          | User device platform (e.g. `ios`, `android`).                 |
+| `deviceInfo`          | `String`              |          | Human-readable device model / OS information.                 |
 
 ### `ActivationLayer2Response` (v4, inside `AeadEncryptedResponse`)
 

--- a/docs/RESTful-API-Methods.md
+++ b/docs/RESTful-API-Methods.md
@@ -200,9 +200,9 @@ Renames an activation. Signature-authenticated, response encrypted.
 
 **Request** `ActivationRenameRequest`:
 
-| Field            | Type     | Required | Description                 |
-|------------------|----------|----------|-----------------------------|
-| `activationName` | `String` | ✓        | New name for the activation |. |
+| Field            | Type     | Required | Description                  |
+|------------------|----------|----------|------------------------------|
+| `activationName` | `String` | ✓        | New name for the activation. |
 
 **Response** `ObjectResponse<ActivationDetailResponse>` (encrypted):
 
@@ -620,7 +620,7 @@ Starts the upgrade of an activation from protocol v3 to v4. Requires both `X-Pow
 
 | Field   | Type     | Required | Description                                                       |
 |---------|----------|----------|-------------------------------------------------------------------|
-| `ecdsa` | `String` | ✓        | Base64-encoded device ECDSA public key                            |.       |
+| `ecdsa` | `String` | ✓        | Base64-encoded device ECDSA public key.                           |
 | `mldsa` | `String` |          | Base64-encoded device ML-DSA public key (optional, post-quantum). |
 
 **Response payload** `UpgradeResponsePayload` (inside `AeadEncryptedResponse`):

--- a/docs/RESTful-API-for-Spring.md
+++ b/docs/RESTful-API-for-Spring.md
@@ -473,7 +473,7 @@ The response data is automatically encrypted using the previously created an AEA
 Note: You can use `String` or `byte[]` data types instead of using request/response objects for encryption of raw data.
 <!-- end -->
 
-### Service Configuration
+## Service Configuration
 
 The following configuration properties can be configured to control service behavior: 
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -6,6 +6,7 @@
 
 - [Introduction](./Introduction.md)
 - [RESTful API (Spring)](./RESTful-API-for-Spring.md)
+- [RESTful API Methods](./RESTful-API-Methods.md)
 - [Error Codes](./Error-Codes.md)
 
 **Implementation Tutorials**

--- a/powerauth-restful-model/pom.xml
+++ b/powerauth-restful-model/pom.xml
@@ -43,6 +43,18 @@
             <artifactId>powerauth-java-crypto</artifactId>
             <version>${powerauth-crypto.version}</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItem.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItem.java
@@ -1,0 +1,50 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.entity;
+
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Entity representing a single configuration item delivered to a mobile SDK caller.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class ConfigItem {
+
+    /**
+     * Configuration item key.
+     */
+    private String key;
+
+    /**
+     * Configuration item value; a scalar or a nested object.
+     */
+    @ToString.Exclude
+    private Object value;
+
+    /**
+     * Scope the item was delivered under, either {@code APPLICATION} or {@code ACTIVATION}.
+     */
+    private ConfigScope scope;
+
+}
+

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItem.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItem.java
@@ -19,32 +19,25 @@
  */
 package com.wultra.security.powerauth.rest.api.model.entity;
 
-import lombok.Data;
-import lombok.ToString;
-
 /**
  * Entity representing a single configuration item delivered to a mobile SDK caller.
  *
+ * @param key Configuration item key.
+ * @param value Configuration item value: a String value or a nested object.
+ * @param scope Scope the item was delivered under, either {@code APPLICATION} or {@code ACTIVATION}.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-@Data
-public class ConfigItem {
+public record ConfigItem(String key, Object value, ConfigScope scope) {
 
     /**
-     * Configuration item key.
+     * The configuration value is intentionally excluded as it may carry sensitive data.
+     *
+     * @return String representation without the configuration value.
      */
-    private String key;
-
-    /**
-     * Configuration item value; a scalar or a nested object.
-     */
-    @ToString.Exclude
-    private Object value;
-
-    /**
-     * Scope the item was delivered under, either {@code APPLICATION} or {@code ACTIVATION}.
-     */
-    private ConfigScope scope;
+    @Override
+    public String toString() {
+        return "ConfigItem{key='" + key + "', scope=" + scope + '}';
+    }
 
 }
 

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigScope.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigScope.java
@@ -1,0 +1,40 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.entity;
+
+/**
+ * Scope a configuration item.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public enum ConfigScope {
+
+    /**
+     * Application-level scope.
+     */
+    APPLICATION,
+
+    /**
+     * Activation-level scope.
+     */
+    ACTIVATION
+
+}
+

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigScope.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigScope.java
@@ -20,7 +20,7 @@
 package com.wultra.security.powerauth.rest.api.model.entity;
 
 /**
- * Scope a configuration item.
+ * Scope of a configuration item.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
@@ -20,7 +20,6 @@
 package com.wultra.security.powerauth.rest.api.model.response.v4;
 
 import com.wultra.security.powerauth.rest.api.model.entity.ConfigItem;
-import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,15 +27,14 @@ import java.util.List;
 /**
  * Response object for the secure configuration endpoints (V4).
  *
+ * @param config Configuration items.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-@Data
-public class ConfigResponse {
+public record ConfigResponse(List<ConfigItem> config) {
 
-    /**
-     * Configuration items.
-     */
-    private List<ConfigItem> config = new ArrayList<>();
+    public ConfigResponse {
+        config = config == null ? new ArrayList<>() : config;
+    }
 
 }
 

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
@@ -1,0 +1,42 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.response.v4;
+
+import com.wultra.security.powerauth.rest.api.model.entity.ConfigItem;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response object for the secure configuration endpoints (V4).
+ *
+ *  @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class ConfigResponse {
+
+    /**
+     * Configuration items.
+     */
+    private List<ConfigItem> config = new ArrayList<>();
+
+}
+

--- a/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
+++ b/powerauth-restful-model/src/main/java/com/wultra/security/powerauth/rest/api/model/response/v4/ConfigResponse.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Response object for the secure configuration endpoints (V4).
  *
- *  @author Roman Strobl, roman.strobl@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
 public class ConfigResponse {

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItemTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/entity/ConfigItemTest.java
@@ -1,0 +1,45 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ConfigItem}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class ConfigItemTest {
+
+    @Test
+    void toString_excludesSensitiveValue() {
+        final ConfigItem item = new ConfigItem("api_token", "super-secret-value", ConfigScope.ACTIVATION);
+
+        final String result = item.toString();
+
+        assertThat(result)
+                .contains("api_token")
+                .contains("ACTIVATION")
+                .doesNotContain("super-secret-value");
+    }
+
+}

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/entity/TokenResponsePayloadTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/entity/TokenResponsePayloadTest.java
@@ -1,0 +1,46 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link TokenResponsePayload}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class TokenResponsePayloadTest {
+
+    @Test
+    void toString_excludesSensitiveTokenSecret() {
+        final TokenResponsePayload payload = new TokenResponsePayload();
+        payload.setTokenId("token-id-123");
+        payload.setTokenSecret("super-secret-token");
+
+        final String result = payload.toString();
+
+        assertThat(result)
+                .contains("token-id-123")
+                .doesNotContain("super-secret-token");
+    }
+
+}

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationLayer2RequestTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationLayer2RequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.request.v3;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ActivationLayer2Request}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class ActivationLayer2RequestTest {
+
+    @Test
+    void toString_excludesSensitiveActivationOtp() {
+        final ActivationLayer2Request request = new ActivationLayer2Request();
+        request.setActivationName("My device");
+        request.setActivationOtp("secret-otp-1234");
+
+        final String result = request.toString();
+
+        assertThat(result)
+                .contains("My device")
+                .doesNotContain("secret-otp-1234");
+    }
+
+}

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationStatusRequestTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v3/ActivationStatusRequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.request.v3;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ActivationStatusRequest}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class ActivationStatusRequestTest {
+
+    @Test
+    void toString_excludesSensitiveChallenge() {
+        final ActivationStatusRequest request = new ActivationStatusRequest();
+        request.setActivationId("activation-id-123");
+        request.setChallenge("secret-challenge-blob");
+
+        final String result = request.toString();
+
+        assertThat(result)
+                .contains("activation-id-123")
+                .doesNotContain("secret-challenge-blob");
+    }
+
+}

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v4/ActivationLayer2RequestTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/request/v4/ActivationLayer2RequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.request.v4;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ActivationLayer2Request}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class ActivationLayer2RequestTest {
+
+    @Test
+    void toString_excludesSensitiveActivationOtp() {
+        final ActivationLayer2Request request = new ActivationLayer2Request();
+        request.setActivationName("My device");
+        request.setActivationOtp("secret-otp-1234");
+
+        final String result = request.toString();
+
+        assertThat(result)
+                .contains("My device")
+                .doesNotContain("secret-otp-1234");
+    }
+
+}

--- a/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/response/v3/ActivationStatusResponseTest.java
+++ b/powerauth-restful-model/src/test/java/com/wultra/security/powerauth/rest/api/model/response/v3/ActivationStatusResponseTest.java
@@ -1,0 +1,46 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.model.response.v3;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ActivationStatusResponse}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+class ActivationStatusResponseTest {
+
+    @Test
+    void toString_excludesSensitiveNonce() {
+        final ActivationStatusResponse response = new ActivationStatusResponse();
+        response.setActivationId("activation-id-123");
+        response.setNonce("secret-nonce-value");
+
+        final String result = response.toString();
+
+        assertThat(result)
+                .contains("activation-id-123")
+                .doesNotContain("secret-nonce-value");
+    }
+
+}

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthConfigException.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthConfigException.java
@@ -1,0 +1,56 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.spring.exception;
+
+/**
+ * Exception raised in case fetching the secure configuration fails.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PowerAuthConfigException extends Exception {
+
+    private static final String DEFAULT_CODE = "ERR_CONFIG";
+    private static final String DEFAULT_ERROR = "POWER_AUTH_CONFIG_FAILURE";
+
+    /**
+     * Default constructor.
+     */
+    public PowerAuthConfigException() {
+        super(DEFAULT_ERROR);
+    }
+
+    /**
+     * Get the default error code, used for example in REST response.
+     * @return Default error code.
+     */
+    public String getDefaultCode() {
+        return DEFAULT_CODE;
+    }
+
+    /**
+     * Get default error message, used for example in the REST response.
+     * @return Default error message.
+     */
+    public String getDefaultError() {
+        return DEFAULT_ERROR;
+    }
+
+}
+

--- a/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthConfigException.java
+++ b/powerauth-restful-security-spring-annotation/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthConfigException.java
@@ -19,12 +19,17 @@
  */
 package com.wultra.security.powerauth.rest.api.spring.exception;
 
+import java.io.Serial;
+
 /**
  * Exception raised in case fetching the secure configuration fails.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 public class PowerAuthConfigException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 3574858277367637316L;
 
     private static final String DEFAULT_CODE = "ERR_CONFIG";
     private static final String DEFAULT_ERROR = "POWER_AUTH_CONFIG_FAILURE";
@@ -34,6 +39,32 @@ public class PowerAuthConfigException extends Exception {
      */
     public PowerAuthConfigException() {
         super(DEFAULT_ERROR);
+    }
+
+    /**
+     * Constructor with a custom error message.
+     * @param message Error message.
+     */
+    public PowerAuthConfigException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor with a cause.
+     * @param cause Error cause.
+     */
+    public PowerAuthConfigException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor with a message and a cause.
+     *
+     * @param message Error message.
+     * @param cause Error cause.
+     */
+    public PowerAuthConfigException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 
     /**

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/UserInfoController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/UserInfoController.java
@@ -79,7 +79,6 @@ public class UserInfoController {
         logger.info("action: fetchUserInfo, state: initiated, activationId: {}",
                 encryptionContext != null ? encryptionContext.getActivationId() : null);
         if (encryptionContext == null) {
-            logger.warn("Encryption failed");
             throw new PowerAuthEncryptionException("Encryption failed");
         }
 

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ConfigController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ConfigController.java
@@ -66,7 +66,6 @@ public class ConfigController {
     public ConfigResponse fetchApplicationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException, PowerAuthEncryptionException, PowerAuthInvalidRequestException {
         logger.info("action: fetchApplicationConfig, state: initiated");
         if (encryptionContext == null) {
-            logger.warn("Encryption failed");
             throw new PowerAuthEncryptionException("Encryption failed");
         }
         PowerAuthVersionUtil.checkUnsupportedVersionV4(encryptionContext.getVersion());
@@ -90,7 +89,6 @@ public class ConfigController {
     public ConfigResponse fetchActivationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException, PowerAuthEncryptionException, PowerAuthInvalidRequestException {
         logger.info("action: fetchActivationConfig, state: initiated, activationId: {}", encryptionContext != null ? encryptionContext.getActivationId() : null);
         if (encryptionContext == null) {
-            logger.warn("Encryption failed");
             throw new PowerAuthEncryptionException("Encryption failed");
         }
         PowerAuthVersionUtil.checkUnsupportedVersionV4(encryptionContext.getVersion());

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ConfigController.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/controller/v4/ConfigController.java
@@ -1,0 +1,104 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.spring.controller.v4;
+
+import com.wultra.security.powerauth.rest.api.model.response.v4.ConfigResponse;
+import com.wultra.security.powerauth.rest.api.spring.annotation.PowerAuthEncryption;
+import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionContext;
+import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
+import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthConfigException;
+import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthEncryptionException;
+import com.wultra.security.powerauth.rest.api.spring.exception.authentication.PowerAuthInvalidRequestException;
+import com.wultra.security.powerauth.rest.api.spring.service.v4.ConfigService;
+import com.wultra.security.powerauth.rest.api.spring.util.PowerAuthVersionUtil;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller delivering the secure configuration to mobile SDK callers over end-to-end encryption.
+ *
+ * <p><b>PowerAuth protocol versions:</b>
+ * <ul>
+ *     <li>4.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@RestController("configControllerV4")
+@RequestMapping("/pa/v4/config")
+@AllArgsConstructor
+@Slf4j
+public class ConfigController {
+
+    private final ConfigService configServiceV4;
+
+    /**
+     * Fetch the configuration items visible in the application scope.
+     *
+     * @param encryptionContext PowerAuth encryption context.
+     * @return Encrypted application-scope configuration items.
+     * @throws PowerAuthConfigException In case fetching the configuration fails.
+     * @throws PowerAuthEncryptionException In case of failed encryption.
+     * @throws PowerAuthInvalidRequestException In case the PowerAuth protocol version is unsupported.
+     */
+    @PowerAuthEncryption(scope = EncryptionScope.APPLICATION_SCOPE)
+    @PostMapping("application")
+    public ConfigResponse fetchApplicationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException, PowerAuthEncryptionException, PowerAuthInvalidRequestException {
+        logger.info("action: fetchApplicationConfig, state: initiated");
+        if (encryptionContext == null) {
+            logger.warn("Encryption failed");
+            throw new PowerAuthEncryptionException("Encryption failed");
+        }
+        PowerAuthVersionUtil.checkUnsupportedVersionV4(encryptionContext.getVersion());
+
+        final ConfigResponse response = configServiceV4.fetchApplicationConfig(encryptionContext);
+        logger.info("action: fetchApplicationConfig, state: succeeded");
+        return response;
+    }
+
+    /**
+     * Fetch the configuration items visible in the activation scope (post-activation).
+     *
+     * @param encryptionContext PowerAuth encryption context.
+     * @return Encrypted activation-scope configuration items.
+     * @throws PowerAuthConfigException In case fetching the configuration fails.
+     * @throws PowerAuthEncryptionException In case of failed encryption.
+     * @throws PowerAuthInvalidRequestException In case the PowerAuth protocol version is unsupported.
+     */
+    @PowerAuthEncryption(scope = EncryptionScope.ACTIVATION_SCOPE)
+    @PostMapping("activation")
+    public ConfigResponse fetchActivationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException, PowerAuthEncryptionException, PowerAuthInvalidRequestException {
+        logger.info("action: fetchActivationConfig, state: initiated, activationId: {}", encryptionContext != null ? encryptionContext.getActivationId() : null);
+        if (encryptionContext == null) {
+            logger.warn("Encryption failed");
+            throw new PowerAuthEncryptionException("Encryption failed");
+        }
+        PowerAuthVersionUtil.checkUnsupportedVersionV4(encryptionContext.getVersion());
+
+        final ConfigResponse response = configServiceV4.fetchActivationConfig(encryptionContext);
+        logger.info("action: fetchActivationConfig, state: succeeded");
+        return response;
+    }
+
+}
+

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/exception/PowerAuthExceptionHandler.java
@@ -159,6 +159,18 @@ public class PowerAuthExceptionHandler {
     }
 
     /**
+     * Handle PowerAuthConfigException exceptions.
+     * @param ex Exception instance.
+     * @return Error response.
+     */
+    @ExceptionHandler(value = PowerAuthConfigException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handlePowerAuthConfigException(PowerAuthConfigException ex) {
+        logger.warn(ex.getMessage(), ex);
+        return new ErrorResponse(ex.getDefaultCode(), ex.getDefaultError());
+    }
+
+    /**
      * Handle PowerAuthUserStatusException exceptions.
      * @param ex Exception instance.
      * @return Error response.

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
@@ -106,7 +106,7 @@ public class ConfigService {
         } catch (PowerAuthClientException ex) {
             logger.warn("PowerAuth activation configuration fetch failed, error: {}", ex.getMessage());
             logger.debug(ex.getMessage(), ex);
-            throw new PowerAuthConfigException();
+            throw new PowerAuthConfigException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
@@ -77,7 +77,7 @@ public class ConfigService {
         } catch (PowerAuthClientException ex) {
             logger.warn("PowerAuth application configuration fetch failed, error: {}", ex.getMessage());
             logger.debug(ex.getMessage(), ex);
-            throw new PowerAuthConfigException();
+            throw new PowerAuthConfigException(ex);
         }
     }
 

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
@@ -36,6 +36,9 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Service implementing the secure configuration delivery to mobile SDK callers.
  *
@@ -122,17 +125,13 @@ public class ConfigService {
     }
 
     private static ConfigResponse convert(FetchConfigResponse fetchResponse) {
-        final ConfigResponse response = new ConfigResponse();
+        final List<ConfigItem> items = new ArrayList<>();
         if (fetchResponse.getConfigs() != null) {
             for (ConfigStoreItem storeItem : fetchResponse.getConfigs()) {
-                final ConfigItem item = new ConfigItem();
-                item.setKey(storeItem.getKey());
-                item.setValue(storeItem.getValue());
-                item.setScope(convertScope(storeItem.getScope()));
-                response.getConfig().add(item);
+                items.add(new ConfigItem(storeItem.getKey(), storeItem.getValue(), convertScope(storeItem.getScope())));
             }
         }
-        return response;
+        return new ConfigResponse(items);
     }
 
     private static ConfigScope convertScope(com.wultra.security.powerauth.client.model.enumeration.ConfigScope scope) {

--- a/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
+++ b/powerauth-restful-security-spring/src/main/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigService.java
@@ -1,0 +1,148 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.spring.service.v4;
+
+import com.wultra.security.powerauth.client.model.entity.ConfigStoreItem;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.LookupApplicationByAppKeyRequest;
+import com.wultra.security.powerauth.client.model.request.v4.FetchConfigRequest;
+import com.wultra.security.powerauth.client.model.response.LookupApplicationByAppKeyResponse;
+import com.wultra.security.powerauth.client.model.response.v4.FetchConfigResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.rest.api.model.entity.ConfigItem;
+import com.wultra.security.powerauth.rest.api.model.entity.ConfigScope;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ConfigResponse;
+import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionContext;
+import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthConfigException;
+import com.wultra.security.powerauth.rest.api.spring.service.HttpCustomizationService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service implementing the secure configuration delivery to mobile SDK callers.
+ *
+ * <p><b>PowerAuth protocol versions:</b>
+ * <ul>
+ *     <li>4.0</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service("configServiceV4")
+@AllArgsConstructor
+@Slf4j
+public class ConfigService {
+
+    private final PowerAuthClient powerAuthClient;
+    private final HttpCustomizationService httpCustomizationService;
+
+    /**
+     * Fetch the configuration items visible in the application scope.
+     *
+     * @param encryptionContext PowerAuth encryption context derived from the validated E2EE request.
+     * @return Application-scope configuration items.
+     * @throws PowerAuthConfigException In case the internal API call fails.
+     */
+    public ConfigResponse fetchApplicationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException {
+        try {
+            final String applicationId = resolveApplicationId(encryptionContext.getApplicationKey());
+
+            final FetchConfigRequest fetchRequest = new FetchConfigRequest();
+            fetchRequest.setApplicationId(applicationId);
+
+            final FetchConfigResponse fetchResponse = powerAuthClient.fetchConfig(
+                    fetchRequest,
+                    httpCustomizationService.getQueryParams(),
+                    httpCustomizationService.getHttpHeaders()
+            );
+            return convert(fetchResponse);
+        } catch (PowerAuthClientException ex) {
+            logger.warn("PowerAuth application configuration fetch failed, error: {}", ex.getMessage());
+            logger.debug(ex.getMessage(), ex);
+            throw new PowerAuthConfigException();
+        }
+    }
+
+    /**
+     * Fetch the configuration items visible in the activation scope.
+     *
+     * @param encryptionContext PowerAuth encryption context derived from the validated E2EE request.
+     * @return Activation-scope configuration items (application-level sections plus the activation's per-device items).
+     * @throws PowerAuthConfigException In case the internal API call fails.
+     */
+    public ConfigResponse fetchActivationConfig(EncryptionContext encryptionContext) throws PowerAuthConfigException {
+        try {
+            final String applicationId = resolveApplicationId(encryptionContext.getApplicationKey());
+            final String activationId = encryptionContext.getActivationId();
+
+            final FetchConfigRequest fetchRequest = new FetchConfigRequest();
+            fetchRequest.setApplicationId(applicationId);
+            fetchRequest.setActivationId(activationId);
+
+            final FetchConfigResponse fetchResponse = powerAuthClient.fetchConfig(
+                    fetchRequest,
+                    httpCustomizationService.getQueryParams(),
+                    httpCustomizationService.getHttpHeaders()
+            );
+            return convert(fetchResponse);
+        } catch (PowerAuthClientException ex) {
+            logger.warn("PowerAuth activation configuration fetch failed, error: {}", ex.getMessage());
+            logger.debug(ex.getMessage(), ex);
+            throw new PowerAuthConfigException();
+        }
+    }
+
+    private String resolveApplicationId(String applicationKey) throws PowerAuthClientException {
+        final LookupApplicationByAppKeyRequest lookupRequest = new LookupApplicationByAppKeyRequest();
+        lookupRequest.setApplicationKey(applicationKey);
+        final LookupApplicationByAppKeyResponse lookupResponse = powerAuthClient.lookupApplicationByAppKey(
+                lookupRequest,
+                httpCustomizationService.getQueryParams(),
+                httpCustomizationService.getHttpHeaders()
+        );
+        return lookupResponse.getApplicationId();
+    }
+
+    private static ConfigResponse convert(FetchConfigResponse fetchResponse) {
+        final ConfigResponse response = new ConfigResponse();
+        if (fetchResponse.getConfigs() != null) {
+            for (ConfigStoreItem storeItem : fetchResponse.getConfigs()) {
+                final ConfigItem item = new ConfigItem();
+                item.setKey(storeItem.getKey());
+                item.setValue(storeItem.getValue());
+                item.setScope(convertScope(storeItem.getScope()));
+                response.getConfig().add(item);
+            }
+        }
+        return response;
+    }
+
+    private static ConfigScope convertScope(com.wultra.security.powerauth.client.model.enumeration.ConfigScope scope) {
+        if (scope == null) {
+            return null;
+        }
+        return switch (scope) {
+            case APPLICATION -> ConfigScope.APPLICATION;
+            case ACTIVATION -> ConfigScope.ACTIVATION;
+        };
+    }
+
+}

--- a/powerauth-restful-security-spring/src/test/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigServiceTest.java
+++ b/powerauth-restful-security-spring/src/test/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * PowerAuth integration libraries for RESTful API applications, examples and
+ * related software components
+ *
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.rest.api.spring.service.v4;
+
+import com.wultra.security.powerauth.client.model.entity.ConfigStoreItem;
+import com.wultra.security.powerauth.client.model.enumeration.ConfigScope;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.LookupApplicationByAppKeyRequest;
+import com.wultra.security.powerauth.client.model.request.v4.FetchConfigRequest;
+import com.wultra.security.powerauth.client.model.response.LookupApplicationByAppKeyResponse;
+import com.wultra.security.powerauth.client.model.response.v4.FetchConfigResponse;
+import com.wultra.security.powerauth.client.v4.PowerAuthClient;
+import com.wultra.security.powerauth.rest.api.model.entity.ConfigItem;
+import com.wultra.security.powerauth.rest.api.model.response.v4.ConfigResponse;
+import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionContext;
+import com.wultra.security.powerauth.rest.api.spring.encryption.EncryptionScope;
+import com.wultra.security.powerauth.rest.api.spring.exception.PowerAuthConfigException;
+import com.wultra.security.powerauth.rest.api.spring.service.HttpCustomizationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link ConfigService}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfigServiceTest {
+
+    private static final String APPLICATION_KEY = "AIsOlIghnLztV2np3SANnQ==";
+    private static final String APPLICATION_ID = "application-1";
+    private static final String ACTIVATION_ID = "e43a5dec-afea-4f17-a92a-3b5c8a4e1b3e";
+
+    @Mock
+    private PowerAuthClient powerAuthClient;
+
+    @Mock
+    private HttpCustomizationService httpCustomizationService;
+
+    @InjectMocks
+    private ConfigService tested;
+
+    @Test
+    void fetchApplicationConfig_resolvesApplicationIdAndMapsItems() throws Exception {
+        stubLookup();
+        final FetchConfigResponse fetchResponse = new FetchConfigResponse();
+        fetchResponse.setApplicationId(APPLICATION_ID);
+        fetchResponse.getConfigs().add(item("base_url", "https://example.com", ConfigScope.APPLICATION));
+        when(powerAuthClient.fetchConfig(any(FetchConfigRequest.class), any(), any())).thenReturn(fetchResponse);
+
+        final ConfigResponse response = tested.fetchApplicationConfig(context(EncryptionScope.APPLICATION_SCOPE, null));
+
+        final ArgumentCaptor<FetchConfigRequest> captor = ArgumentCaptor.forClass(FetchConfigRequest.class);
+        verify(powerAuthClient).fetchConfig(captor.capture(), any(), any());
+        assertEquals(APPLICATION_ID, captor.getValue().getApplicationId());
+        assertNull(captor.getValue().getActivationId());
+
+        assertEquals(1, response.getConfig().size());
+        final ConfigItem item = response.getConfig().get(0);
+        assertEquals("base_url", item.getKey());
+        assertEquals("https://example.com", item.getValue());
+        assertEquals(com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.APPLICATION, item.getScope());
+    }
+
+    @Test
+    void fetchActivationConfig_passesActivationIdAndMapsScopes() throws Exception {
+        stubLookup();
+        final FetchConfigResponse fetchResponse = new FetchConfigResponse();
+        fetchResponse.setApplicationId(APPLICATION_ID);
+        fetchResponse.setActivationId(ACTIVATION_ID);
+        fetchResponse.getConfigs().add(item("base_url", "https://example.com", ConfigScope.APPLICATION));
+        fetchResponse.getConfigs().add(item("token", "secret", ConfigScope.ACTIVATION));
+        when(powerAuthClient.fetchConfig(any(FetchConfigRequest.class), any(), any())).thenReturn(fetchResponse);
+
+        final ConfigResponse response = tested.fetchActivationConfig(context(EncryptionScope.ACTIVATION_SCOPE, ACTIVATION_ID));
+
+        final ArgumentCaptor<FetchConfigRequest> captor = ArgumentCaptor.forClass(FetchConfigRequest.class);
+        verify(powerAuthClient).fetchConfig(captor.capture(), any(), any());
+        assertEquals(APPLICATION_ID, captor.getValue().getApplicationId());
+        assertEquals(ACTIVATION_ID, captor.getValue().getActivationId());
+
+        assertEquals(List.of(
+                        com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.APPLICATION,
+                        com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.ACTIVATION),
+                response.getConfig().stream().map(ConfigItem::getScope).toList());
+    }
+
+    @Test
+    void fetchApplicationConfig_emptyConfigReturnsEmptyList() throws Exception {
+        stubLookup();
+        when(powerAuthClient.fetchConfig(any(FetchConfigRequest.class), any(), any())).thenReturn(new FetchConfigResponse());
+
+        final ConfigResponse response = tested.fetchApplicationConfig(context(EncryptionScope.APPLICATION_SCOPE, null));
+
+        assertNotNull(response.getConfig());
+        assertTrue(response.getConfig().isEmpty());
+    }
+
+    @Test
+    void fetchApplicationConfig_wrapsClientException() throws Exception {
+        when(powerAuthClient.lookupApplicationByAppKey(any(LookupApplicationByAppKeyRequest.class), any(), any()))
+                .thenThrow(new PowerAuthClientException("client error"));
+
+        assertThrows(PowerAuthConfigException.class,
+                () -> tested.fetchApplicationConfig(context(EncryptionScope.APPLICATION_SCOPE, null)));
+    }
+
+    private void stubLookup() throws PowerAuthClientException {
+        final LookupApplicationByAppKeyResponse lookupResponse = new LookupApplicationByAppKeyResponse();
+        lookupResponse.setApplicationId(APPLICATION_ID);
+        when(powerAuthClient.lookupApplicationByAppKey(any(LookupApplicationByAppKeyRequest.class), any(), any()))
+                .thenReturn(lookupResponse);
+    }
+
+    private static ConfigStoreItem item(String key, Object value, ConfigScope scope) {
+        final ConfigStoreItem item = new ConfigStoreItem();
+        item.setKey(key);
+        item.setValue(value);
+        item.setScope(scope);
+        return item;
+    }
+
+    private static EncryptionContext context(EncryptionScope scope, String activationId) {
+        return new EncryptionContext(APPLICATION_KEY, activationId, "4.0", null, scope);
+    }
+
+}
+

--- a/powerauth-restful-security-spring/src/test/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigServiceTest.java
+++ b/powerauth-restful-security-spring/src/test/java/com/wultra/security/powerauth/rest/api/spring/service/v4/ConfigServiceTest.java
@@ -83,11 +83,11 @@ class ConfigServiceTest {
         assertEquals(APPLICATION_ID, captor.getValue().getApplicationId());
         assertNull(captor.getValue().getActivationId());
 
-        assertEquals(1, response.getConfig().size());
-        final ConfigItem item = response.getConfig().get(0);
-        assertEquals("base_url", item.getKey());
-        assertEquals("https://example.com", item.getValue());
-        assertEquals(com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.APPLICATION, item.getScope());
+        assertEquals(1, response.config().size());
+        final ConfigItem item = response.config().get(0);
+        assertEquals("base_url", item.key());
+        assertEquals("https://example.com", item.value());
+        assertEquals(com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.APPLICATION, item.scope());
     }
 
     @Test
@@ -110,7 +110,7 @@ class ConfigServiceTest {
         assertEquals(List.of(
                         com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.APPLICATION,
                         com.wultra.security.powerauth.rest.api.model.entity.ConfigScope.ACTIVATION),
-                response.getConfig().stream().map(ConfigItem::getScope).toList());
+                response.config().stream().map(ConfigItem::scope).toList());
     }
 
     @Test
@@ -120,8 +120,8 @@ class ConfigServiceTest {
 
         final ConfigResponse response = tested.fetchApplicationConfig(context(EncryptionScope.APPLICATION_SCOPE, null));
 
-        assertNotNull(response.getConfig());
-        assertTrue(response.getConfig().isEmpty());
+        assertNotNull(response.config());
+        assertTrue(response.config().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### What
Adds two new end-to-end-encrypted REST endpoints (`POST /pa/v4/config/application` and `POST /pa/v4/config/activation`) that deliver configuration items stored in PowerAuth Server to the mobile SDK caller. Also renames `Changelog.md` to `CHANGELOG.md` and reformats it to the Keep a Changelog 1.1.0 style.

### Why
Mobile SDK clients need a secure, encrypted channel to retrieve server-side configuration. The endpoints are part of the PowerAuth v4 protocol and require end-to-end encryption to protect the payload in transit.

### How
- **`powerauth-restful-model`** — new `ConfigScope` enum (`APPLICATION`/`ACTIVATION`), `ConfigItem` entity (`key`, `value`, `scope`), and `ConfigResponse` DTO wrapping a list of `ConfigItem`.
- **`powerauth-restful-security-spring-annotation`** — new `PowerAuthConfigException` (checked, mirrors the existing exception pattern with `ERR_CONFIG` / `POWER_AUTH_CONFIG_FAILURE` codes).
- **`powerauth-restful-security-spring`**:
  - `ConfigService` (v4) — resolves the application ID via `LookupApplicationByAppKey`, calls `PowerAuthClient.fetchConfig`, and maps `ConfigStoreItem` list to `ConfigResponse`. Separate methods for application and activation scope.
  - `ConfigController` (v4) — `POST /pa/v4/config/application` (application-scope encryption) and `POST /pa/v4/config/activation` (activation-scope encryption).
  - `PowerAuthExceptionHandler` — added handler for `PowerAuthConfigException` returning HTTP 400.
- **Changelog** — renamed `Changelog.md` → `CHANGELOG.md`; reformatted to Keep a Changelog 1.1.0 with `### Added` / `### Changed` sections.

### Testing
- `ConfigServiceTest` (4 unit tests with Mockito): application-config happy path, activation-config happy path with scope mapping, empty config, and client-exception wrapping.
- Will be later tested by powerauth-cmd-tool and powerauth-backend-tests.

### Closes
Closes #714