### PR TITLE
Docs #717: Consolidate CHANGELOG.md and add Copilot changelog instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,73 @@
+# Copilot Instructions — powerauth-restful-integration
+
+This file captures conventions used when working with GitHub Copilot in the
+`powerauth-restful-integration` repository and the broader Wultra PowerAuth ecosystem.
+
+---
+
+## Changelog
+
+`CHANGELOG.md` lives at the **repo root**. Update it as part of every PR — before creating
+the PR, not after merge.
+
+### Format
+
+Strictly follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- New feature description [(#N)](https://github.com/wultra/powerauth-restful-integration/issues/N)
+
+### Changed
+- Changed behaviour description [(#N)](...)
+
+### Fixed
+- Bug fix description [(#N)](...)
+
+## [1.2.3] - 2025-03-01
+### Added
+- ...
+
+[unreleased]: https://github.com/wultra/powerauth-restful-integration/compare/1.2.3...HEAD
+[1.2.3]: https://github.com/wultra/powerauth-restful-integration/compare/1.2.2...1.2.3
+```
+
+**Change type subsections** (use only those that apply):
+- `Added` — new features
+- `Changed` — changes in existing functionality
+- `Deprecated` — soon-to-be removed features
+- `Removed` — removed features
+- `Fixed` — bug fixes
+- `Security` — security vulnerability fixes
+
+**Rules:**
+- The header must mention both [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Always add new entries under the `## [Unreleased]` section at the top.
+- On release: rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` (ISO 8601 date), add a
+  fresh empty `## [Unreleased]` above it, update the `[unreleased]` reference link, and add
+  the new version's compare link at the bottom.
+- Versions and sections must be linkable via reference-style links at the bottom of the file.
+- Each entry: `- <Description starting with a verb> [(#N)](url)` — link to the **issue**, not
+  the PR.
+- Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when
+  application list is empty" not "fix #811: add missing import").
+- Skip the Changelog update only for changes with no user-visible impact (e.g. pure
+  CI/tooling changes).
+
+---
+
+## License
+
+`powerauth-restful-integration` is **open-source**, licensed under the
+[GNU AGPLv3](../LICENSE). New source files use the AGPL header consistent with existing
+files in the repository — do not introduce a proprietary license header here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-All notable changes to this project are documented in this file, following the
-[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -15,7 +17,7 @@ All notable changes to this project are documented in this file, following the
 
 ### Changed
 
-- Allow 1FA activation remove in v3 endpoint [(#704)](https://github.com/wultra/powerauth-restful-integration/pull/704)
+- Allow 1FA activation remove in v3 endpoint [(#684)](https://github.com/wultra/powerauth-restful-integration/issues/684)
 - Migrate to Spring Boot 4 and Jackson 3 [(#705)](https://github.com/wultra/powerauth-restful-integration/issues/705)
 - Update Spring Boot version [(#720)](https://github.com/wultra/powerauth-restful-integration/issues/720)
 
@@ -23,3 +25,6 @@ All notable changes to this project are documented in this file, following the
 
 - Authentication token status should match authentication context [(#707)](https://github.com/wultra/powerauth-restful-integration/issues/707)
 - Register Lombok annotation processor [(#709)](https://github.com/wultra/powerauth-restful-integration/issues/709)
+
+[unreleased]: https://github.com/wultra/powerauth-restful-integration/compare/2.2.0...HEAD
+[2.2.0]: https://github.com/wultra/powerauth-restful-integration/compare/2.1.1...2.2.0


### PR DESCRIPTION
## Description
Consolidates the root `CHANGELOG.md` to strictly follow Keep a Changelog 1.1.0 and adds `.github/copilot-instructions.md` documenting the changelog conventions, per the parent epic wultra/tasklist#986.

- `CHANGELOG.md`: header now mentions both Keep a Changelog and Semantic Versioning; fixed an entry that linked to PR #704 instead of the actual issue (#684); added reference-style compare links (`[unreleased]`, `[2.2.0]`) at the bottom.
- Added `.github/copilot-instructions.md` documenting the strict changelog convention for this repo.

## Motivation and Context
Standardize changelog and Copilot conventions across Wultra PowerAuth repositories (see epic wultra/tasklist#986). This repo is single-product, so only the root `CHANGELOG.md` is affected.

## Testing
Documentation-only change; no code affected. No build/test run required.

## Closes
Closes #717
